### PR TITLE
Feat/edit option apartment

### DIFF
--- a/backend/internal/apartment/apartment.go
+++ b/backend/internal/apartment/apartment.go
@@ -13,7 +13,7 @@ type CreateApartmentInput struct {
 	Bathrooms     int
 	BaseRent      int
 	AvailableFrom string
-	ImageURLs     []string
+	ImagePaths    []string
 	Status        string
 	Latitude      float64
 	Longitude     float64
@@ -31,7 +31,6 @@ type Apartment struct {
 	Title         string
 	Description   string
 	OwnerID       string
-	OwnerName     string
 	Address       string
 	Area          string
 	TotalSpots    int
@@ -39,7 +38,7 @@ type Apartment struct {
 	BaseRent      int
 	Status        string
 	CreatedAt     string
-	ImageURL      string
+	ImagePaths    []string
 	ImageURLs     []string
 	Latitude      float64
 	Longitude     float64

--- a/backend/internal/apartment/apartment.go
+++ b/backend/internal/apartment/apartment.go
@@ -40,6 +40,7 @@ type Apartment struct {
 	Status        string
 	CreatedAt     string
 	ImageURL      string
+	ImageURLs     []string
 	Latitude      float64
 	Longitude     float64
 }

--- a/backend/internal/apartment/httpadapter/handler.go
+++ b/backend/internal/apartment/httpadapter/handler.go
@@ -260,24 +260,29 @@ func (h *handler) uploadApartmentPhotos(c *gin.Context) {
 	}
 
 	files := make([]apartmentservice.UploadFile, 0, len(formFiles))
-	for _, fh := range formFiles {
-		data, err := fh.Open()
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("could not read file %q", fh.Filename)})
-			return
-		}
-		fileData, err := io.ReadAll(data)
-		data.Close()
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("could not read file %q", fh.Filename)})
-			return
-		}
-		files = append(files, apartmentservice.UploadFile{
-			Filename:    fh.Filename,
-			ContentType: fh.Header.Get("Content-Type"),
-			Data:        fileData,
-		})
-	}
+    for _, fh := range formFiles {
+        data, err := fh.Open()
+        if err != nil {
+            c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("could not read file %q", fh.Filename)})
+            return
+        }
+        fileData, readErr := io.ReadAll(data)
+        closeErr := data.Close()
+        if readErr != nil {
+            c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("could not read file %q", fh.Filename)})
+            return
+        }
+        if closeErr != nil {
+            // Closing the uploaded file failed — treat as internal error.
+            c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("could not close file %q", fh.Filename)})
+            return
+        }
+        files = append(files, apartmentservice.UploadFile{
+            Filename:    fh.Filename,
+            ContentType: fh.Header.Get("Content-Type"),
+            Data:        fileData,
+        })
+    }
 
 	results, err := h.apartmentService.UploadApartmentPhotos(c.Request.Context(), ownerID, role, apartmentID, apartmentName, files)
 	if err != nil {

--- a/backend/internal/apartment/httpadapter/handler.go
+++ b/backend/internal/apartment/httpadapter/handler.go
@@ -2,6 +2,8 @@ package httpadapter
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -25,7 +27,7 @@ type createApartmentRequest struct {
 	Bathrooms     int      `json:"bathrooms"`
 	BaseRent      int      `json:"base_rent"`
 	AvailableFrom string   `json:"available_from"`
-	ImageURLs     []string `json:"image_urls"`
+	ImagePaths    []string `json:"image_paths"`
 	Latitude      float64  `json:"latitude"`
 	Longitude     float64  `json:"longitude"`
 }
@@ -43,26 +45,28 @@ type ownerApartmentResponse struct {
 	CreatedAt     string   `json:"created_at"`
 	ImageURL      string   `json:"image_url"`
 	ImageURLs     []string `json:"image_urls"`
+	ImagePaths    []string `json:"image_paths"`
 	Latitude      float64  `json:"latitude"`
 	Longitude     float64  `json:"longitude"`
 }
 
 type tenantApartmentResponse struct {
-	ID             string  `json:"id"`
-	Title          string  `json:"title"`
-	Description    string  `json:"description"`
-	Address        string  `json:"address"`
-	Area           string  `json:"area"`
-	TotalSpots     int     `json:"total_spots"`
-	AvailableSpots int     `json:"available_spots"`
-	BaseRent       int     `json:"base_rent"`
-	Status         string  `json:"status"`
-	CreatedAt      string  `json:"created_at"`
-	ImageURL       string  `json:"image_url"`
-	OwnerName      string  `json:"owner_name"`
-	Compatibility  int     `json:"compatibility_score"`
-	Latitude       float64 `json:"latitude"`
-	Longitude      float64 `json:"longitude"`
+	ID             string   `json:"id"`
+	Title          string   `json:"title"`
+	Description    string   `json:"description"`
+	Address        string   `json:"address"`
+	Area           string   `json:"area"`
+	TotalSpots     int      `json:"total_spots"`
+	AvailableSpots int      `json:"available_spots"`
+	BaseRent       int      `json:"base_rent"`
+	Status         string   `json:"status"`
+	CreatedAt      string   `json:"created_at"`
+	ImageURL       string   `json:"image_url"`
+	ImageURLs      []string `json:"image_urls"`
+	ImagePaths     []string `json:"image_paths"`
+	Compatibility  int      `json:"compatibility_score"`
+	Latitude       float64  `json:"latitude"`
+	Longitude      float64  `json:"longitude"`
 }
 
 type tenantApartmentDetailResponse struct {
@@ -101,6 +105,7 @@ func RegisterOwnerRoutes(api *gin.RouterGroup, apartmentService *apartmentservic
 	api.GET("/owner/apartments", h.listOwnerApartments)
 	api.GET("/owner/apartments/:id", h.getOwnerApartment)
 	api.PATCH("/owner/apartments/:id", h.updateOwnerApartment)
+	api.POST("/owner/apartment-photos", h.uploadApartmentPhotos)
 	api.POST("/apartments", h.createApartment)
 }
 
@@ -229,6 +234,64 @@ func (h *handler) updateOwnerApartment(c *gin.Context) {
 	})
 }
 
+func (h *handler) uploadApartmentPhotos(c *gin.Context) {
+	ownerID, role, ok := h.resolveUserAndRole(c)
+	if !ok {
+		return
+	}
+
+	if err := c.Request.ParseMultipartForm(50 << 20); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid multipart form"})
+		return
+	}
+
+	apartmentID := strings.TrimSpace(c.PostForm("apartment_id"))
+	apartmentName := strings.TrimSpace(c.PostForm("apartment_name"))
+
+	form, err := c.MultipartForm()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid multipart form"})
+		return
+	}
+	formFiles := form.File["photos"]
+	if len(formFiles) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "at least one photo is required"})
+		return
+	}
+
+	files := make([]apartmentservice.UploadFile, 0, len(formFiles))
+	for _, fh := range formFiles {
+		data, err := fh.Open()
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("could not read file %q", fh.Filename)})
+			return
+		}
+		fileData, err := io.ReadAll(data)
+		data.Close()
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("could not read file %q", fh.Filename)})
+			return
+		}
+		files = append(files, apartmentservice.UploadFile{
+			Filename:    fh.Filename,
+			ContentType: fh.Header.Get("Content-Type"),
+			Data:        fileData,
+		})
+	}
+
+	results, err := h.apartmentService.UploadApartmentPhotos(c.Request.Context(), ownerID, role, apartmentID, apartmentName, files)
+	if err != nil {
+		if errors.Is(err, apartmentservice.ErrOwnerRequired) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "apartment photos are only available for owner users"})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"photos": results})
+}
+
 func (h *handler) getApartmentDetail(c *gin.Context) {
 	tenantID, role, ok := h.resolveUserAndRole(c)
 	if !ok {
@@ -265,8 +328,9 @@ func (h *handler) getApartmentDetail(c *gin.Context) {
 			BaseRent:       detail.Apartment.BaseRent,
 			Status:         detail.Apartment.Status,
 			CreatedAt:      detail.Apartment.CreatedAt,
-			ImageURL:       detail.Apartment.ImageURL,
-			OwnerName:      detail.Apartment.OwnerName,
+			ImageURL:       firstImageURL(detail.Apartment.ImageURLs),
+			ImageURLs:      nonNilStrings(detail.Apartment.ImageURLs),
+			ImagePaths:     nonNilStrings(detail.Apartment.ImagePaths),
 			Compatibility:  detail.CompatibilityScore,
 		},
 		CompatibilityReasons: detail.CompatibilityReason,
@@ -361,7 +425,7 @@ func apartmentInputFromRequest(request createApartmentRequest) apartment.CreateA
 		Bathrooms:     request.Bathrooms,
 		BaseRent:      request.BaseRent,
 		AvailableFrom: request.AvailableFrom,
-		ImageURLs:     request.ImageURLs,
+		ImagePaths:    request.ImagePaths,
 		Latitude:      request.Latitude,
 		Longitude:     request.Longitude,
 	}
@@ -373,15 +437,15 @@ func normalizeApartmentInput(input *apartment.CreateApartmentInput) {
 	input.Address = strings.TrimSpace(input.Address)
 	input.Area = strings.TrimSpace(input.Area)
 	input.AvailableFrom = strings.TrimSpace(input.AvailableFrom)
-	cleanURLs := make([]string, 0, len(input.ImageURLs))
-	for _, imageURL := range input.ImageURLs {
-		trimmed := strings.TrimSpace(imageURL)
+	cleanPaths := make([]string, 0, len(input.ImagePaths))
+	for _, imagePath := range input.ImagePaths {
+		trimmed := strings.TrimSpace(imagePath)
 		if trimmed == "" {
 			continue
 		}
-		cleanURLs = append(cleanURLs, trimmed)
+		cleanPaths = append(cleanPaths, trimmed)
 	}
-	input.ImageURLs = cleanURLs
+	input.ImagePaths = cleanPaths
 }
 
 func ownerApartmentResponses(apartments []apartment.Apartment) []ownerApartmentResponse {
@@ -393,10 +457,8 @@ func ownerApartmentResponses(apartments []apartment.Apartment) []ownerApartmentR
 }
 
 func ownerApartmentResponseFrom(item apartment.Apartment) ownerApartmentResponse {
-	imageURLs := item.ImageURLs
-	if imageURLs == nil {
-		imageURLs = []string{}
-	}
+	imagePaths := nonNilStrings(item.ImagePaths)
+	imageURLs := nonNilStrings(item.ImageURLs)
 	return ownerApartmentResponse{
 		ID:            item.ID,
 		Title:         item.Title,
@@ -408,8 +470,9 @@ func ownerApartmentResponseFrom(item apartment.Apartment) ownerApartmentResponse
 		BaseRent:      item.BaseRent,
 		Status:        item.Status,
 		CreatedAt:     item.CreatedAt,
-		ImageURL:      item.ImageURL,
+		ImageURL:      firstImageURL(imageURLs),
 		ImageURLs:     imageURLs,
+		ImagePaths:    imagePaths,
 		Latitude:      item.Latitude,
 		Longitude:     item.Longitude,
 	}
@@ -418,6 +481,7 @@ func ownerApartmentResponseFrom(item apartment.Apartment) ownerApartmentResponse
 func tenantApartmentResponses(apartments []apartment.Apartment) []tenantApartmentResponse {
 	responses := make([]tenantApartmentResponse, 0, len(apartments))
 	for _, item := range apartments {
+		imageURLs := nonNilStrings(item.ImageURLs)
 		responses = append(responses, tenantApartmentResponse{
 			ID:             item.ID,
 			Title:          item.Title,
@@ -429,12 +493,27 @@ func tenantApartmentResponses(apartments []apartment.Apartment) []tenantApartmen
 			BaseRent:       item.BaseRent,
 			Status:         item.Status,
 			CreatedAt:      item.CreatedAt,
-			ImageURL:       item.ImageURL,
-			OwnerName:      item.OwnerName,
+			ImageURL:       firstImageURL(imageURLs),
+			ImageURLs:      imageURLs,
+			ImagePaths:     nonNilStrings(item.ImagePaths),
 			Compatibility:  0,
 			Latitude:       item.Latitude,
 			Longitude:      item.Longitude,
 		})
 	}
 	return responses
+}
+
+func firstImageURL(imageURLs []string) string {
+	if len(imageURLs) == 0 {
+		return ""
+	}
+	return imageURLs[0]
+}
+
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
 }

--- a/backend/internal/apartment/httpadapter/handler.go
+++ b/backend/internal/apartment/httpadapter/handler.go
@@ -31,18 +31,20 @@ type createApartmentRequest struct {
 }
 
 type ownerApartmentResponse struct {
-	ID            string  `json:"id"`
-	Title         string  `json:"title"`
-	Address       string  `json:"address"`
-	Area          string  `json:"area"`
-	TotalSpots    int     `json:"total_spots"`
-	OccupiedSpots int     `json:"occupied_spots"`
-	BaseRent      int     `json:"base_rent"`
-	Status        string  `json:"status"`
-	CreatedAt     string  `json:"created_at"`
-	ImageURL      string  `json:"image_url"`
-	Latitude      float64 `json:"latitude"`
-	Longitude     float64 `json:"longitude"`
+	ID            string   `json:"id"`
+	Title         string   `json:"title"`
+	Description   string   `json:"description"`
+	Address       string   `json:"address"`
+	Area          string   `json:"area"`
+	TotalSpots    int      `json:"total_spots"`
+	OccupiedSpots int      `json:"occupied_spots"`
+	BaseRent      int      `json:"base_rent"`
+	Status        string   `json:"status"`
+	CreatedAt     string   `json:"created_at"`
+	ImageURL      string   `json:"image_url"`
+	ImageURLs     []string `json:"image_urls"`
+	Latitude      float64  `json:"latitude"`
+	Longitude     float64  `json:"longitude"`
 }
 
 type tenantApartmentResponse struct {
@@ -97,6 +99,8 @@ func RegisterTenantRoutes(api *gin.RouterGroup, apartmentService *apartmentservi
 func RegisterOwnerRoutes(api *gin.RouterGroup, apartmentService *apartmentservice.Service) {
 	h := &handler{apartmentService: apartmentService}
 	api.GET("/owner/apartments", h.listOwnerApartments)
+	api.GET("/owner/apartments/:id", h.getOwnerApartment)
+	api.PATCH("/owner/apartments/:id", h.updateOwnerApartment)
 	api.POST("/apartments", h.createApartment)
 }
 
@@ -140,7 +144,7 @@ func (h *handler) createApartment(c *gin.Context) {
 	if !ok {
 		return
 	}
-	input, ok := bindAndValidateApartmentInput(c)
+	input, ok := bindAndValidateApartmentInput(c, true)
 	if !ok {
 		return
 	}
@@ -159,6 +163,69 @@ func (h *handler) createApartment(c *gin.Context) {
 		"message":       "apartment published successfully",
 		"apartment_id":  result.ApartmentID,
 		"images_stored": result.ImagesStored,
+	})
+}
+
+func (h *handler) getOwnerApartment(c *gin.Context) {
+	ownerID, role, ok := h.resolveUserAndRole(c)
+	if !ok {
+		return
+	}
+	apartmentID := strings.TrimSpace(c.Param("id"))
+	if apartmentID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "apartment id is required"})
+		return
+	}
+
+	item, err := h.apartmentService.GetOwnerApartment(c.Request.Context(), ownerID, role, apartmentID)
+	if err != nil {
+		if errors.Is(err, apartmentservice.ErrOwnerRequired) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "apartments are only available for owner users"})
+			return
+		}
+		if errors.Is(err, apartmentservice.ErrApartmentNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "apartment not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "could not load owner apartment"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"apartment": ownerApartmentResponseFrom(*item)})
+}
+
+func (h *handler) updateOwnerApartment(c *gin.Context) {
+	ownerID, role, ok := h.resolveUserAndRole(c)
+	if !ok {
+		return
+	}
+	apartmentID := strings.TrimSpace(c.Param("id"))
+	if apartmentID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "apartment id is required"})
+		return
+	}
+	input, ok := bindAndValidateApartmentInput(c, false)
+	if !ok {
+		return
+	}
+
+	item, err := h.apartmentService.UpdateOwnerApartment(c.Request.Context(), ownerID, role, apartmentID, input)
+	if err != nil {
+		if errors.Is(err, apartmentservice.ErrOwnerRequired) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "apartments are only available for owner users"})
+			return
+		}
+		if errors.Is(err, apartmentservice.ErrApartmentNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "apartment not found"})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":   "apartment updated successfully",
+		"apartment": ownerApartmentResponseFrom(*item),
 	})
 }
 
@@ -245,7 +312,7 @@ func (h *handler) resolveUserAndRole(c *gin.Context) (string, string, bool) {
 	return userID, role, true
 }
 
-func bindAndValidateApartmentInput(c *gin.Context) (apartment.CreateApartmentInput, bool) {
+func bindAndValidateApartmentInput(c *gin.Context, requirePublishOnlyFields bool) (apartment.CreateApartmentInput, bool) {
 	var request createApartmentRequest
 	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -265,7 +332,7 @@ func bindAndValidateApartmentInput(c *gin.Context) (apartment.CreateApartmentInp
 		c.JSON(http.StatusBadRequest, gin.H{"error": "total_spots must be greater than zero"})
 		return apartment.CreateApartmentInput{}, false
 	}
-	if input.Bathrooms <= 0 {
+	if requirePublishOnlyFields && input.Bathrooms <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "bathrooms must be greater than zero"})
 		return apartment.CreateApartmentInput{}, false
 	}
@@ -273,7 +340,7 @@ func bindAndValidateApartmentInput(c *gin.Context) (apartment.CreateApartmentInp
 		c.JSON(http.StatusBadRequest, gin.H{"error": "base_rent must be greater than zero"})
 		return apartment.CreateApartmentInput{}, false
 	}
-	if strings.TrimSpace(input.AvailableFrom) != "" {
+	if requirePublishOnlyFields && strings.TrimSpace(input.AvailableFrom) != "" {
 		if _, err := time.Parse("2006-01-02", input.AvailableFrom); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "available_from must have YYYY-MM-DD format"})
 			return apartment.CreateApartmentInput{}, false
@@ -320,22 +387,32 @@ func normalizeApartmentInput(input *apartment.CreateApartmentInput) {
 func ownerApartmentResponses(apartments []apartment.Apartment) []ownerApartmentResponse {
 	responses := make([]ownerApartmentResponse, 0, len(apartments))
 	for _, item := range apartments {
-		responses = append(responses, ownerApartmentResponse{
-			ID:            item.ID,
-			Title:         item.Title,
-			Address:       item.Address,
-			Area:          item.Area,
-			TotalSpots:    item.TotalSpots,
-			OccupiedSpots: item.OccupiedSpots,
-			BaseRent:      item.BaseRent,
-			Status:        item.Status,
-			CreatedAt:     item.CreatedAt,
-			ImageURL:      item.ImageURL,
-			Latitude:      item.Latitude,
-			Longitude:     item.Longitude,
-		})
+		responses = append(responses, ownerApartmentResponseFrom(item))
 	}
 	return responses
+}
+
+func ownerApartmentResponseFrom(item apartment.Apartment) ownerApartmentResponse {
+	imageURLs := item.ImageURLs
+	if imageURLs == nil {
+		imageURLs = []string{}
+	}
+	return ownerApartmentResponse{
+		ID:            item.ID,
+		Title:         item.Title,
+		Description:   item.Description,
+		Address:       item.Address,
+		Area:          item.Area,
+		TotalSpots:    item.TotalSpots,
+		OccupiedSpots: item.OccupiedSpots,
+		BaseRent:      item.BaseRent,
+		Status:        item.Status,
+		CreatedAt:     item.CreatedAt,
+		ImageURL:      item.ImageURL,
+		ImageURLs:     imageURLs,
+		Latitude:      item.Latitude,
+		Longitude:     item.Longitude,
+	}
 }
 
 func tenantApartmentResponses(apartments []apartment.Apartment) []tenantApartmentResponse {

--- a/backend/internal/apartment/httpadapter/handler_test.go
+++ b/backend/internal/apartment/httpadapter/handler_test.go
@@ -12,6 +12,8 @@ func TestTenantApartmentResponsesDerivesAvailableSpots(t *testing.T) {
 		Title:         "Flat",
 		TotalSpots:    3,
 		OccupiedSpots: 1,
+		ImagePaths:    []string{"apartments/apartment-1/photo.jpg"},
+		ImageURLs:     []string{"https://signed.example.test/apartments/apartment-1/photo.jpg"},
 	}})
 
 	if len(responses) != 1 {
@@ -19,5 +21,33 @@ func TestTenantApartmentResponsesDerivesAvailableSpots(t *testing.T) {
 	}
 	if responses[0].AvailableSpots != 2 {
 		t.Fatalf("AvailableSpots = %d, want 2", responses[0].AvailableSpots)
+	}
+	if responses[0].ImageURL != "https://signed.example.test/apartments/apartment-1/photo.jpg" {
+		t.Fatalf("ImageURL = %q, want first signed image URL", responses[0].ImageURL)
+	}
+	if len(responses[0].ImageURLs) != 1 || responses[0].ImageURLs[0] != "https://signed.example.test/apartments/apartment-1/photo.jpg" {
+		t.Fatalf("ImageURLs = %#v, want signed image URLs", responses[0].ImageURLs)
+	}
+	if len(responses[0].ImagePaths) != 1 || responses[0].ImagePaths[0] != "apartments/apartment-1/photo.jpg" {
+		t.Fatalf("ImagePaths = %#v, want raw image paths", responses[0].ImagePaths)
+	}
+}
+
+func TestOwnerApartmentResponseReturnsSignedURLsAndRawPaths(t *testing.T) {
+	response := ownerApartmentResponseFrom(apartment.Apartment{
+		ID:         "apartment-1",
+		Title:      "Flat",
+		ImagePaths: []string{"apartments/apartment-1/photo.jpg"},
+		ImageURLs:  []string{"https://signed.example.test/apartments/apartment-1/photo.jpg"},
+	})
+
+	if response.ImageURL != "https://signed.example.test/apartments/apartment-1/photo.jpg" {
+		t.Fatalf("ImageURL = %q, want first signed image URL", response.ImageURL)
+	}
+	if len(response.ImageURLs) != 1 || response.ImageURLs[0] != "https://signed.example.test/apartments/apartment-1/photo.jpg" {
+		t.Fatalf("ImageURLs = %#v, want signed image URLs", response.ImageURLs)
+	}
+	if len(response.ImagePaths) != 1 || response.ImagePaths[0] != "apartments/apartment-1/photo.jpg" {
+		t.Fatalf("ImagePaths = %#v, want raw image paths", response.ImagePaths)
 	}
 }

--- a/backend/internal/apartment/postgres/repository.go
+++ b/backend/internal/apartment/postgres/repository.go
@@ -63,20 +63,20 @@ func (r *Repository) CreateApartment(ctx context.Context, ownerID string, input 
 		return "", 0, fmt.Errorf("insert apartment: %w", err)
 	}
 
-	stored := 0
-	if len(input.ImageURLs) > 0 {
-		const insertPhotoSQL = `INSERT INTO public.apartment_photos (apartment_id, url, position) VALUES ($1, $2, $3)`
-		for idx, imageURL := range input.ImageURLs {
-			trimmedURL := strings.TrimSpace(imageURL)
-			if trimmedURL == "" {
-				continue
-			}
-			if _, err := tx.Exec(ctx, insertPhotoSQL, apartmentID, trimmedURL, idx); err != nil {
-				return "", 0, fmt.Errorf("insert apartment photo: %w", err)
-			}
-			stored++
-		}
-	}
+    stored := 0
+    if len(input.ImagePaths) > 0 {
+        const insertPhotoSQL = `INSERT INTO public.apartment_photos (apartment_id, url, position) VALUES ($1, $2, $3)`
+        for idx, imagePath := range input.ImagePaths {
+            trimmedPath := strings.TrimSpace(imagePath)
+            if trimmedPath == "" {
+                continue
+            }
+            if _, err := tx.Exec(ctx, insertPhotoSQL, apartmentID, trimmedPath, idx); err != nil {
+                return "", 0, fmt.Errorf("insert apartment photo: %w", err)
+            }
+            stored++
+        }
+    }
 
 	if err := tx.Commit(ctx); err != nil {
 		return "", 0, fmt.Errorf("commit create apartment tx: %w", err)
@@ -87,28 +87,27 @@ func (r *Repository) CreateApartment(ctx context.Context, ownerID string, input 
 
 // ListOwnerApartments returns apartments published by an owner.
 func (r *Repository) ListOwnerApartments(ctx context.Context, ownerID string) ([]apartment.Apartment, error) {
-	const query = `SELECT
-		a.id,
-		a.title,
-		a.address,
-		COALESCE(a.area, ''),
-		a.total_spots,
-		a.occupied_spots,
-		a.base_rent,
-		a.status,
-		TO_CHAR(a.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
-		COALESCE((
-			SELECT ap.url
-			FROM public.apartment_photos ap
-			WHERE ap.apartment_id = a.id
-			ORDER BY ap.position ASC, ap.created_at ASC
-			LIMIT 1
-		), '') AS image_url,
-		COALESCE(a.latitude, 0),
-		COALESCE(a.longitude, 0)
-	FROM public.apartments a
-	WHERE a.owner_id = $1
-	ORDER BY a.created_at DESC`
+    const query = `SELECT
+        a.id,
+        a.title,
+        a.address,
+        COALESCE(a.area, ''),
+        a.total_spots,
+        a.occupied_spots,
+        a.base_rent,
+        a.status,
+        TO_CHAR(a.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
+        ARRAY(
+            SELECT ap.url
+            FROM public.apartment_photos ap
+            WHERE ap.apartment_id = a.id
+            ORDER BY ap.position ASC, ap.created_at ASC
+        ) AS image_paths,
+        COALESCE(a.latitude, 0),
+        COALESCE(a.longitude, 0)
+    FROM public.apartments a
+    WHERE a.owner_id = $1
+    ORDER BY a.created_at DESC`
 
 	rows, err := r.db.Query(ctx, query, ownerID)
 	if err != nil {
@@ -119,22 +118,22 @@ func (r *Repository) ListOwnerApartments(ctx context.Context, ownerID string) ([
 	result := make([]apartment.Apartment, 0)
 	for rows.Next() {
 		var item apartment.Apartment
-		if err := rows.Scan(
-			&item.ID,
-			&item.Title,
-			&item.Address,
-			&item.Area,
-			&item.TotalSpots,
-			&item.OccupiedSpots,
-			&item.BaseRent,
-			&item.Status,
-			&item.CreatedAt,
-			&item.ImageURL,
-			&item.Latitude,
-			&item.Longitude,
-		); err != nil {
-			return nil, fmt.Errorf("scan owner apartments: %w", err)
-		}
+        if err := rows.Scan(
+            &item.ID,
+            &item.Title,
+            &item.Address,
+            &item.Area,
+            &item.TotalSpots,
+            &item.OccupiedSpots,
+            &item.BaseRent,
+            &item.Status,
+            &item.CreatedAt,
+            &item.ImagePaths,
+            &item.Latitude,
+            &item.Longitude,
+        ); err != nil {
+            return nil, fmt.Errorf("scan owner apartments: %w", err)
+        }
 		result = append(result, item)
 	}
 	if err := rows.Err(); err != nil {
@@ -156,24 +155,24 @@ func (r *Repository) ListAvailableApartments(ctx context.Context, filters apartm
 	result := make([]apartment.Apartment, 0)
 	for rows.Next() {
 		var item apartment.Apartment
-		if err := rows.Scan(
-			&item.ID,
-			&item.Title,
-			&item.Address,
-			&item.Area,
-			&item.TotalSpots,
-			&item.OccupiedSpots,
-			&item.BaseRent,
-			&item.Status,
-			&item.CreatedAt,
-			&item.ImageURL,
-			&item.Latitude,
-			&item.Longitude,
-		); err != nil {
-			return nil, fmt.Errorf("scan available apartments: %w", err)
-		}
-		result = append(result, item)
-	}
+        if err := rows.Scan(
+            &item.ID,
+            &item.Title,
+            &item.Address,
+            &item.Area,
+            &item.TotalSpots,
+            &item.OccupiedSpots,
+            &item.BaseRent,
+            &item.Status,
+            &item.CreatedAt,
+            &item.ImagePaths,
+            &item.Latitude,
+            &item.Longitude,
+        ); err != nil {
+            return nil, fmt.Errorf("scan available apartments: %w", err)
+        }
+        result = append(result, item)
+    }
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate available apartments: %w", err)
 	}
@@ -187,27 +186,26 @@ type availableApartmentsQuery struct {
 }
 
 func buildListAvailableApartmentsQuery(filters apartment.ListApartmentsFilters) availableApartmentsQuery {
-	baseQuery := `SELECT
-		a.id,
-		a.title,
-		a.address,
-		COALESCE(a.area, ''),
-		a.total_spots,
-		a.occupied_spots,
-		a.base_rent,
-		a.status,
-		TO_CHAR(a.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
-		COALESCE((
-			SELECT ap.url
-			FROM public.apartment_photos ap
-			WHERE ap.apartment_id = a.id
-			ORDER BY ap.position ASC, ap.created_at ASC
-			LIMIT 1
-		), '') AS image_url,
-		COALESCE(a.latitude, 0),
-		COALESCE(a.longitude, 0)
-	FROM public.apartments a
-	WHERE 1=1`
+    baseQuery := `SELECT
+        a.id,
+        a.title,
+        a.address,
+        COALESCE(a.area, ''),
+        a.total_spots,
+        a.occupied_spots,
+        a.base_rent,
+        a.status,
+        TO_CHAR(a.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
+        ARRAY(
+            SELECT ap.url
+            FROM public.apartment_photos ap
+            WHERE ap.apartment_id = a.id
+            ORDER BY ap.position ASC, ap.created_at ASC
+        ) AS image_paths,
+        COALESCE(a.latitude, 0),
+        COALESCE(a.longitude, 0)
+    FROM public.apartments a
+    WHERE 1=1`
 
 	whereClauses := make([]string, 0, 8)
 	args := make([]interface{}, 0, 12)
@@ -289,54 +287,46 @@ func buildAvailableApartmentsOrderBy(sortBy string) string {
 
 // GetOwnerApartmentByID returns one apartment when it belongs to the owner.
 func (r *Repository) GetOwnerApartmentByID(ctx context.Context, ownerID, apartmentID string) (*apartment.Apartment, error) {
-	const query = `SELECT
-		a.id,
-		a.title,
-		COALESCE(a.description, ''),
-		a.owner_id,
-		a.address,
-		COALESCE(a.area, ''),
-		a.total_spots,
-		a.occupied_spots,
-		a.base_rent,
-		a.status,
-		TO_CHAR(a.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
-		COALESCE((
-			SELECT ap.url
-			FROM public.apartment_photos ap
-			WHERE ap.apartment_id = a.id
-			ORDER BY ap.position ASC, ap.created_at ASC
-			LIMIT 1
-		), '') AS image_url,
-		ARRAY(
-			SELECT ap.url
-			FROM public.apartment_photos ap
-			WHERE ap.apartment_id = a.id
-			ORDER BY ap.position ASC, ap.created_at ASC
-		) AS image_urls,
-		COALESCE(a.latitude, 0),
-		COALESCE(a.longitude, 0)
-	FROM public.apartments a
-	WHERE a.id = $1 AND a.owner_id = $2`
+    const query = `SELECT
+        a.id,
+        a.title,
+        COALESCE(a.description, ''),
+        a.owner_id,
+        a.address,
+        COALESCE(a.area, ''),
+        a.total_spots,
+        a.occupied_spots,
+        a.base_rent,
+        a.status,
+        TO_CHAR(a.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
+        ARRAY(
+            SELECT ap.url
+            FROM public.apartment_photos ap
+            WHERE ap.apartment_id = a.id
+            ORDER BY ap.position ASC, ap.created_at ASC
+        ) AS image_paths,
+        COALESCE(a.latitude, 0),
+        COALESCE(a.longitude, 0)
+    FROM public.apartments a
+    WHERE a.id = $1 AND a.owner_id = $2`
 
 	var item apartment.Apartment
-	err := r.db.QueryRow(ctx, query, apartmentID, ownerID).Scan(
-		&item.ID,
-		&item.Title,
-		&item.Description,
-		&item.OwnerID,
-		&item.Address,
-		&item.Area,
-		&item.TotalSpots,
-		&item.OccupiedSpots,
-		&item.BaseRent,
-		&item.Status,
-		&item.CreatedAt,
-		&item.ImageURL,
-		&item.ImageURLs,
-		&item.Latitude,
-		&item.Longitude,
-	)
+    err := r.db.QueryRow(ctx, query, apartmentID, ownerID).Scan(
+        &item.ID,
+        &item.Title,
+        &item.Description,
+        &item.OwnerID,
+        &item.Address,
+        &item.Area,
+        &item.TotalSpots,
+        &item.OccupiedSpots,
+        &item.BaseRent,
+        &item.Status,
+        &item.CreatedAt,
+        &item.ImagePaths,
+        &item.Latitude,
+        &item.Longitude,
+    )
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
@@ -394,16 +384,16 @@ func (r *Repository) UpdateOwnerApartment(ctx context.Context, ownerID, apartmen
 	if _, err := tx.Exec(ctx, `DELETE FROM public.apartment_photos WHERE apartment_id = $1`, apartmentID); err != nil {
 		return nil, fmt.Errorf("delete apartment photos: %w", err)
 	}
-	const insertPhotoSQL = `INSERT INTO public.apartment_photos (apartment_id, url, position) VALUES ($1, $2, $3)`
-	for idx, imageURL := range input.ImageURLs {
-		trimmedURL := strings.TrimSpace(imageURL)
-		if trimmedURL == "" {
-			continue
-		}
-		if _, err := tx.Exec(ctx, insertPhotoSQL, apartmentID, trimmedURL, idx); err != nil {
-			return nil, fmt.Errorf("insert apartment photo: %w", err)
-		}
-	}
+    const insertPhotoSQL = `INSERT INTO public.apartment_photos (apartment_id, url, position) VALUES ($1, $2, $3)`
+    for idx, imagePath := range input.ImagePaths {
+        trimmedPath := strings.TrimSpace(imagePath)
+        if trimmedPath == "" {
+            continue
+        }
+        if _, err := tx.Exec(ctx, insertPhotoSQL, apartmentID, trimmedPath, idx); err != nil {
+            return nil, fmt.Errorf("insert apartment photo: %w", err)
+        }
+    }
 
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit update apartment tx: %w", err)
@@ -414,50 +404,46 @@ func (r *Repository) UpdateOwnerApartment(ctx context.Context, ownerID, apartmen
 
 // GetApartmentByID returns one apartment by id.
 func (r *Repository) GetApartmentByID(ctx context.Context, apartmentID string) (*apartment.Apartment, error) {
-	const query = `SELECT
-		a.id,
-		a.title,
-		COALESCE(a.description, ''),
-		a.owner_id,
-		COALESCE(u.full_name, ''),
-		a.address,
-		COALESCE(a.area, ''),
-		a.total_spots,
-		a.occupied_spots,
-		a.base_rent,
-		a.status,
-		TO_CHAR(a.created_at, 'YYYY-MM-DD') AS created_at,
-		COALESCE((
-			SELECT ap.url
-			FROM public.apartment_photos ap
-			WHERE ap.apartment_id = a.id
-			ORDER BY ap.position ASC, ap.created_at ASC
-			LIMIT 1
-		), '') AS image_url,
-		COALESCE(a.latitude, 0),
-		COALESCE(a.longitude, 0)
-	FROM public.apartments a
-	LEFT JOIN public.users u ON u.id = a.owner_id
-	WHERE a.id = $1`
+    const query = `SELECT
+        a.id,
+        a.title,
+        COALESCE(a.description, ''),
+        a.owner_id,
+        a.address,
+        COALESCE(a.area, ''),
+        a.total_spots,
+        a.occupied_spots,
+        a.base_rent,
+        a.status,
+        TO_CHAR(a.created_at, 'YYYY-MM-DD') AS created_at,
+        ARRAY(
+            SELECT ap.url
+            FROM public.apartment_photos ap
+            WHERE ap.apartment_id = a.id
+            ORDER BY ap.position ASC, ap.created_at ASC
+        ) AS image_paths,
+        COALESCE(a.latitude, 0),
+        COALESCE(a.longitude, 0)
+    FROM public.apartments a
+    WHERE a.id = $1`
 
-	var item apartment.Apartment
-	err := r.db.QueryRow(ctx, query, apartmentID).Scan(
-		&item.ID,
-		&item.Title,
-		&item.Description,
-		&item.OwnerID,
-		&item.OwnerName,
-		&item.Address,
-		&item.Area,
-		&item.TotalSpots,
-		&item.OccupiedSpots,
-		&item.BaseRent,
-		&item.Status,
-		&item.CreatedAt,
-		&item.ImageURL,
-		&item.Latitude,
-		&item.Longitude,
-	)
+    var item apartment.Apartment
+    err := r.db.QueryRow(ctx, query, apartmentID).Scan(
+        &item.ID,
+        &item.Title,
+        &item.Description,
+        &item.OwnerID,
+        &item.Address,
+        &item.Area,
+        &item.TotalSpots,
+        &item.OccupiedSpots,
+        &item.BaseRent,
+        &item.Status,
+        &item.CreatedAt,
+        &item.ImagePaths,
+        &item.Latitude,
+        &item.Longitude,
+    )
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil

--- a/backend/internal/apartment/postgres/repository.go
+++ b/backend/internal/apartment/postgres/repository.go
@@ -287,6 +287,131 @@ func buildAvailableApartmentsOrderBy(sortBy string) string {
 	}
 }
 
+// GetOwnerApartmentByID returns one apartment when it belongs to the owner.
+func (r *Repository) GetOwnerApartmentByID(ctx context.Context, ownerID, apartmentID string) (*apartment.Apartment, error) {
+	const query = `SELECT
+		a.id,
+		a.title,
+		COALESCE(a.description, ''),
+		a.owner_id,
+		a.address,
+		COALESCE(a.area, ''),
+		a.total_spots,
+		a.occupied_spots,
+		a.base_rent,
+		a.status,
+		TO_CHAR(a.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
+		COALESCE((
+			SELECT ap.url
+			FROM public.apartment_photos ap
+			WHERE ap.apartment_id = a.id
+			ORDER BY ap.position ASC, ap.created_at ASC
+			LIMIT 1
+		), '') AS image_url,
+		ARRAY(
+			SELECT ap.url
+			FROM public.apartment_photos ap
+			WHERE ap.apartment_id = a.id
+			ORDER BY ap.position ASC, ap.created_at ASC
+		) AS image_urls,
+		COALESCE(a.latitude, 0),
+		COALESCE(a.longitude, 0)
+	FROM public.apartments a
+	WHERE a.id = $1 AND a.owner_id = $2`
+
+	var item apartment.Apartment
+	err := r.db.QueryRow(ctx, query, apartmentID, ownerID).Scan(
+		&item.ID,
+		&item.Title,
+		&item.Description,
+		&item.OwnerID,
+		&item.Address,
+		&item.Area,
+		&item.TotalSpots,
+		&item.OccupiedSpots,
+		&item.BaseRent,
+		&item.Status,
+		&item.CreatedAt,
+		&item.ImageURL,
+		&item.ImageURLs,
+		&item.Latitude,
+		&item.Longitude,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get owner apartment by id: %w", err)
+	}
+	return &item, nil
+}
+
+// UpdateOwnerApartment updates one apartment when it belongs to the owner.
+func (r *Repository) UpdateOwnerApartment(ctx context.Context, ownerID, apartmentID string, input apartment.CreateApartmentInput) (*apartment.Apartment, error) {
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin update apartment tx: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	const updateApartmentSQL = `UPDATE public.apartments
+	SET title = $3,
+		description = $4,
+		address = $5,
+		area = $6,
+		total_spots = $7,
+		available_spots = $7 - occupied_spots,
+		base_rent = $8,
+		current_rent = $8,
+		latitude = $9,
+		longitude = $10
+	WHERE id = $1 AND owner_id = $2
+	RETURNING id`
+
+	var updatedID string
+	if err := tx.QueryRow(
+		ctx,
+		updateApartmentSQL,
+		apartmentID,
+		ownerID,
+		input.Title,
+		nullIfEmpty(input.Description),
+		input.Address,
+		nullIfEmpty(input.Area),
+		input.TotalSpots,
+		input.BaseRent,
+		input.Latitude,
+		input.Longitude,
+	).Scan(&updatedID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("update apartment: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM public.apartment_photos WHERE apartment_id = $1`, apartmentID); err != nil {
+		return nil, fmt.Errorf("delete apartment photos: %w", err)
+	}
+	const insertPhotoSQL = `INSERT INTO public.apartment_photos (apartment_id, url, position) VALUES ($1, $2, $3)`
+	for idx, imageURL := range input.ImageURLs {
+		trimmedURL := strings.TrimSpace(imageURL)
+		if trimmedURL == "" {
+			continue
+		}
+		if _, err := tx.Exec(ctx, insertPhotoSQL, apartmentID, trimmedURL, idx); err != nil {
+			return nil, fmt.Errorf("insert apartment photo: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit update apartment tx: %w", err)
+	}
+
+	return r.GetOwnerApartmentByID(ctx, ownerID, apartmentID)
+}
+
 // GetApartmentByID returns one apartment by id.
 func (r *Repository) GetApartmentByID(ctx context.Context, apartmentID string) (*apartment.Apartment, error) {
 	const query = `SELECT

--- a/backend/internal/apartment/service/service.go
+++ b/backend/internal/apartment/service/service.go
@@ -2,9 +2,13 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
+	"mime"
+	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/isw2-unileon/proyect-scaffolding/backend/internal/apartment"
 	"github.com/isw2-unileon/proyect-scaffolding/backend/internal/application"
@@ -30,8 +34,22 @@ type applicationReader interface {
 	GetTenantApplicationForApartment(ctx context.Context, apartmentID, tenantID string) (string, string, error)
 }
 
-type imageURLSigner interface {
+type imageStorage interface {
 	CreateSignedURL(ctx context.Context, bucket string, path string, expiresIn int) (string, error)
+	UploadObject(ctx context.Context, bucket, objectPath, contentType string, fileData []byte) error
+}
+
+// UploadFile represents a photo file to upload.
+type UploadFile struct {
+	Filename    string
+	ContentType string
+	Data        []byte
+}
+
+// UploadResult represents an uploaded photo.
+type UploadResult struct {
+	Path      string `json:"path"`
+	SignedURL string `json:"signed_url"`
 }
 
 const (
@@ -62,12 +80,12 @@ type Service struct {
 	repo              repository
 	profileReader     profileReader
 	applicationReader applicationReader
-	imageSigner       imageURLSigner
+	imageStorage      imageStorage
 }
 
 // NewService creates the apartment service.
-func NewService(repo repository, imageSigner imageURLSigner, profileReader profileReader, applicationReader applicationReader) *Service {
-	return &Service{repo: repo, imageSigner: imageSigner, profileReader: profileReader, applicationReader: applicationReader}
+func NewService(repo repository, imageStorage imageStorage, profileReader profileReader, applicationReader applicationReader) *Service {
+	return &Service{repo: repo, imageStorage: imageStorage, profileReader: profileReader, applicationReader: applicationReader}
 }
 
 // CreateApartment validates and stores a new owner apartment listing.
@@ -159,7 +177,6 @@ func (s *Service) GetOwnerApartment(ctx context.Context, ownerID, role, apartmen
 	if item == nil {
 		return nil, ErrApartmentNotFound
 	}
-
 	signed, err := s.signApartmentImages(ctx, []apartment.Apartment{*item})
 	if err != nil {
 		return nil, err
@@ -216,7 +233,6 @@ func (s *Service) UpdateOwnerApartment(ctx context.Context, ownerID, role, apart
 	if updated == nil {
 		return nil, ErrApartmentNotFound
 	}
-
 	signed, err := s.signApartmentImages(ctx, []apartment.Apartment{*updated})
 	if err != nil {
 		return nil, err
@@ -345,34 +361,30 @@ func (s *Service) GetApartmentDetailForTenant(ctx context.Context, apartmentID, 
 }
 
 func (s *Service) signApartmentImages(ctx context.Context, apartments []apartment.Apartment) ([]apartment.Apartment, error) {
-	if s.imageSigner == nil {
-		return apartments, nil
-	}
 	for idx := range apartments {
-		signedURL, err := s.signedImageURL(ctx, apartments[idx].ImageURL)
-		if err != nil {
-			apartments[idx].ImageURL = ""
-			continue
+		if apartments[idx].ImagePaths == nil {
+			apartments[idx].ImagePaths = []string{}
 		}
-		apartments[idx].ImageURL = signedURL
-		apartments[idx].ImageURLs = s.signedImageURLs(ctx, apartments[idx].ImageURLs)
+
+		imageURLs := make([]string, 0, len(apartments[idx].ImagePaths))
+		for _, imagePath := range apartments[idx].ImagePaths {
+			trimmed := strings.TrimSpace(imagePath)
+			if trimmed == "" {
+				continue
+			}
+			if s.imageStorage == nil && !isAbsoluteHTTPURL(trimmed) {
+				continue
+			}
+
+			signedURL, err := s.signedImageURL(ctx, trimmed)
+			if err != nil || signedURL == "" {
+				continue
+			}
+			imageURLs = append(imageURLs, signedURL)
+		}
+		apartments[idx].ImageURLs = imageURLs
 	}
 	return apartments, nil
-}
-
-func (s *Service) signedImageURLs(ctx context.Context, imagePaths []string) []string {
-	if len(imagePaths) == 0 {
-		return imagePaths
-	}
-	signedURLs := make([]string, 0, len(imagePaths))
-	for _, imagePath := range imagePaths {
-		signedURL, err := s.signedImageURL(ctx, imagePath)
-		if err != nil || signedURL == "" {
-			continue
-		}
-		signedURLs = append(signedURLs, signedURL)
-	}
-	return signedURLs
 }
 
 func (s *Service) signedImageURL(ctx context.Context, imagePath string) (string, error) {
@@ -380,11 +392,21 @@ func (s *Service) signedImageURL(ctx context.Context, imagePath string) (string,
 	if imagePath == "" {
 		return "", nil
 	}
-	signedURL, err := s.imageSigner.CreateSignedURL(ctx, apartmentPhotosBucket, imagePath, signedImageURLTTLSeconds)
+	if isAbsoluteHTTPURL(imagePath) {
+		return imagePath, nil
+	}
+	if s.imageStorage == nil {
+		return "", nil
+	}
+	signedURL, err := s.imageStorage.CreateSignedURL(ctx, apartmentPhotosBucket, imagePath, signedImageURLTTLSeconds)
 	if err != nil {
 		return "", fmt.Errorf("sign apartment image: %w", err)
 	}
 	return signedURL, nil
+}
+
+func isAbsoluteHTTPURL(value string) bool {
+	return strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://")
 }
 
 func derefRules(rules *apartment.Rules) apartment.Rules {
@@ -392,4 +414,86 @@ func derefRules(rules *apartment.Rules) apartment.Rules {
 		return apartment.Rules{}
 	}
 	return *rules
+}
+
+const (
+	maxPhotosPerApartment = 8
+	maxPhotoSizeBytes     = 5 * 1024 * 1024
+)
+
+// UploadApartmentPhotos uploads photo files to Supabase Storage.
+func (s *Service) UploadApartmentPhotos(ctx context.Context, ownerID, role, apartmentID, apartmentName string, files []UploadFile) ([]UploadResult, error) {
+	if strings.TrimSpace(ownerID) == "" {
+		return nil, errors.New("owner id is required")
+	}
+	if strings.ToLower(strings.TrimSpace(role)) != "owner" {
+		return nil, ErrOwnerRequired
+	}
+	if s.imageStorage == nil {
+		return nil, errors.New("image upload is not configured")
+	}
+	if len(files) == 0 {
+		return nil, errors.New("at least one photo is required")
+	}
+	if len(files) > maxPhotosPerApartment {
+		return nil, fmt.Errorf("too many photos, maximum %d allowed", maxPhotosPerApartment)
+	}
+
+	apartmentID = strings.TrimSpace(apartmentID)
+	if apartmentID == "" {
+		b := make([]byte, 16)
+		_, _ = rand.Read(b)
+		apartmentID = fmt.Sprintf("%x", b)
+	}
+	folderName := storageFolderName(apartmentName, apartmentID)
+
+	results := make([]UploadResult, 0, len(files))
+	for i, file := range files {
+		if len(file.Data) > maxPhotoSizeBytes {
+			return nil, fmt.Errorf("file %q exceeds maximum size of 5MB", file.Filename)
+		}
+		ext := filepath.Ext(strings.TrimSpace(file.Filename))
+		if ext == "" {
+			ext = ".jpg"
+		}
+		objectPath := fmt.Sprintf("%s/%d%s", folderName, i, ext)
+		contentType := file.ContentType
+		if contentType == "" {
+			contentType = mime.TypeByExtension(ext)
+			if contentType == "" {
+				contentType = "application/octet-stream"
+			}
+		}
+
+		if err := s.imageStorage.UploadObject(ctx, apartmentPhotosBucket, objectPath, contentType, file.Data); err != nil {
+			return nil, fmt.Errorf("upload photo %q: %w", file.Filename, err)
+		}
+
+		signedURL, err := s.signedImageURL(ctx, objectPath)
+		if err != nil {
+			return nil, fmt.Errorf("sign uploaded photo %q: %w", file.Filename, err)
+		}
+
+		results = append(results, UploadResult{Path: objectPath, SignedURL: signedURL})
+	}
+	return results, nil
+}
+
+func storageFolderName(apartmentName, apartmentID string) string {
+	name := strings.Trim(strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return r
+		}
+		if unicode.IsSpace(r) || r == '-' || r == '_' {
+			return '-'
+		}
+		return -1
+	}, strings.TrimSpace(apartmentName)), "-")
+	if name == "" {
+		name = "apartment"
+	}
+	if len(name) > 50 {
+		name = strings.TrimRight(name[:50], "-")
+	}
+	return name + "-" + apartmentID
 }

--- a/backend/internal/apartment/service/service.go
+++ b/backend/internal/apartment/service/service.go
@@ -15,6 +15,8 @@ import (
 type repository interface {
 	CreateApartment(ctx context.Context, ownerID string, input apartment.CreateApartmentInput) (string, int, error)
 	ListOwnerApartments(ctx context.Context, ownerID string) ([]apartment.Apartment, error)
+	GetOwnerApartmentByID(ctx context.Context, ownerID, apartmentID string) (*apartment.Apartment, error)
+	UpdateOwnerApartment(ctx context.Context, ownerID, apartmentID string, input apartment.CreateApartmentInput) (*apartment.Apartment, error)
 	ListAvailableApartments(ctx context.Context, filters apartment.ListApartmentsFilters) ([]apartment.Apartment, error)
 	GetApartmentByID(ctx context.Context, apartmentID string) (*apartment.Apartment, error)
 	GetApartmentRules(ctx context.Context, apartmentID string) (*apartment.Rules, error)
@@ -135,6 +137,91 @@ func (s *Service) ListOwnerApartments(ctx context.Context, ownerID, role string)
 		return nil, err
 	}
 	return s.signApartmentImages(ctx, apartments)
+}
+
+// GetOwnerApartment returns one apartment owned by the current owner.
+func (s *Service) GetOwnerApartment(ctx context.Context, ownerID, role, apartmentID string) (*apartment.Apartment, error) {
+	if strings.TrimSpace(ownerID) == "" {
+		return nil, errors.New("owner id is required")
+	}
+	if strings.ToLower(strings.TrimSpace(role)) != "owner" {
+		return nil, ErrOwnerRequired
+	}
+	apartmentID = strings.TrimSpace(apartmentID)
+	if apartmentID == "" {
+		return nil, errors.New("apartment id is required")
+	}
+
+	item, err := s.repo.GetOwnerApartmentByID(ctx, ownerID, apartmentID)
+	if err != nil {
+		return nil, err
+	}
+	if item == nil {
+		return nil, ErrApartmentNotFound
+	}
+
+	signed, err := s.signApartmentImages(ctx, []apartment.Apartment{*item})
+	if err != nil {
+		return nil, err
+	}
+	return &signed[0], nil
+}
+
+// UpdateOwnerApartment validates and updates an existing owner apartment listing.
+func (s *Service) UpdateOwnerApartment(ctx context.Context, ownerID, role, apartmentID string, input apartment.CreateApartmentInput) (*apartment.Apartment, error) {
+	if strings.TrimSpace(ownerID) == "" {
+		return nil, errors.New("owner id is required")
+	}
+	if strings.ToLower(strings.TrimSpace(role)) != "owner" {
+		return nil, ErrOwnerRequired
+	}
+	apartmentID = strings.TrimSpace(apartmentID)
+	if apartmentID == "" {
+		return nil, errors.New("apartment id is required")
+	}
+	if strings.TrimSpace(input.Title) == "" {
+		return nil, errors.New("title is required")
+	}
+	if strings.TrimSpace(input.Address) == "" {
+		return nil, errors.New("address is required")
+	}
+	if input.TotalSpots <= 0 {
+		return nil, errors.New("total_spots must be greater than zero")
+	}
+	if input.BaseRent <= 0 {
+		return nil, errors.New("base_rent must be greater than zero")
+	}
+
+	owned, err := s.repo.GetOwnerApartmentByID(ctx, ownerID, apartmentID)
+	if err != nil {
+		return nil, err
+	}
+	if owned == nil {
+		return nil, ErrApartmentNotFound
+	}
+	if input.TotalSpots < owned.OccupiedSpots {
+		return nil, errors.New("total_spots cannot be lower than occupied_spots")
+	}
+
+	input.Title = strings.TrimSpace(input.Title)
+	input.Description = strings.TrimSpace(input.Description)
+	input.Address = strings.TrimSpace(input.Address)
+	input.Area = strings.TrimSpace(input.Area)
+	input.Status = owned.Status
+
+	updated, err := s.repo.UpdateOwnerApartment(ctx, ownerID, apartmentID, input)
+	if err != nil {
+		return nil, err
+	}
+	if updated == nil {
+		return nil, ErrApartmentNotFound
+	}
+
+	signed, err := s.signApartmentImages(ctx, []apartment.Apartment{*updated})
+	if err != nil {
+		return nil, err
+	}
+	return &signed[0], nil
 }
 
 // ListAvailableApartments returns tenant-visible apartment listings.
@@ -268,8 +355,24 @@ func (s *Service) signApartmentImages(ctx context.Context, apartments []apartmen
 			continue
 		}
 		apartments[idx].ImageURL = signedURL
+		apartments[idx].ImageURLs = s.signedImageURLs(ctx, apartments[idx].ImageURLs)
 	}
 	return apartments, nil
+}
+
+func (s *Service) signedImageURLs(ctx context.Context, imagePaths []string) []string {
+	if len(imagePaths) == 0 {
+		return imagePaths
+	}
+	signedURLs := make([]string, 0, len(imagePaths))
+	for _, imagePath := range imagePaths {
+		signedURL, err := s.signedImageURL(ctx, imagePath)
+		if err != nil || signedURL == "" {
+			continue
+		}
+		signedURLs = append(signedURLs, signedURL)
+	}
+	return signedURLs
 }
 
 func (s *Service) signedImageURL(ctx context.Context, imagePath string) (string, error) {

--- a/backend/internal/apartment/service/service_test.go
+++ b/backend/internal/apartment/service/service_test.go
@@ -12,11 +12,14 @@ import (
 type fakeApartmentRepository struct {
 	createdDescription string
 	createdStatus      string
+	updatedDescription string
+	updatedTotalSpots  int
 
 	applicationForApartmentID     string
 	applicationForApartmentStatus string
 
 	ownerApartments  []apartment.Apartment
+	ownerApartment   *apartment.Apartment
 	tenantApartments []apartment.Apartment
 	apartmentByID    *apartment.Apartment
 	apartmentRules   *apartment.Rules
@@ -34,6 +37,16 @@ func (f *fakeApartmentRepository) ListOwnerApartments(ctx context.Context, owner
 		return f.ownerApartments, nil
 	}
 	return []apartment.Apartment{{ID: "apartment-1", Title: "Flat"}}, nil
+}
+
+func (f *fakeApartmentRepository) GetOwnerApartmentByID(ctx context.Context, ownerID, apartmentID string) (*apartment.Apartment, error) {
+	return f.ownerApartment, nil
+}
+
+func (f *fakeApartmentRepository) UpdateOwnerApartment(ctx context.Context, ownerID, apartmentID string, input apartment.CreateApartmentInput) (*apartment.Apartment, error) {
+	f.updatedDescription = input.Description
+	f.updatedTotalSpots = input.TotalSpots
+	return &apartment.Apartment{ID: apartmentID, Title: input.Title, Description: input.Description, TotalSpots: input.TotalSpots}, nil
 }
 
 func (f *fakeApartmentRepository) ListAvailableApartments(ctx context.Context, filters apartment.ListApartmentsFilters) ([]apartment.Apartment, error) {
@@ -181,6 +194,96 @@ func TestListOwnerApartmentsSignsImagePaths(t *testing.T) {
 	}
 	if signer.expiresIn != 3600 {
 		t.Fatalf("expiresIn = %d, want 3600", signer.expiresIn)
+	}
+}
+
+func TestGetOwnerApartmentReturnsOwnedApartmentWithSignedImages(t *testing.T) {
+	repo := &fakeApartmentRepository{
+		ownerApartment: &apartment.Apartment{
+			ID:        "apartment-1",
+			Title:     "Flat",
+			ImageURL:  "apartments/apartment-1/front.jpg",
+			ImageURLs: []string{"apartments/apartment-1/front.jpg", "apartments/apartment-1/room.jpg"},
+		},
+	}
+	signer := &fakeImageSigner{}
+	svc := NewService(repo, signer, repo, repo)
+
+	result, err := svc.GetOwnerApartment(context.Background(), "owner-1", "owner", "apartment-1")
+	if err != nil {
+		t.Fatalf("GetOwnerApartment returned error: %v", err)
+	}
+
+	if result == nil || result.ID != "apartment-1" {
+		t.Fatalf("result ID = %#v, want apartment-1", result)
+	}
+	if result.ImageURL != "https://signed.example.test/apartments/apartment-1/front.jpg" {
+		t.Fatalf("ImageURL = %q, want signed front image", result.ImageURL)
+	}
+	if len(result.ImageURLs) != 2 || result.ImageURLs[1] != "https://signed.example.test/apartments/apartment-1/room.jpg" {
+		t.Fatalf("ImageURLs = %#v, want signed image list", result.ImageURLs)
+	}
+}
+
+func TestGetOwnerApartmentReturnsNotFoundWhenRepositoryHasNoOwnedApartment(t *testing.T) {
+	repo := &fakeApartmentRepository{}
+	svc := NewService(repo, nil, repo, repo)
+
+	_, err := svc.GetOwnerApartment(context.Background(), "owner-1", "owner", "missing")
+	if !errors.Is(err, ErrApartmentNotFound) {
+		t.Fatalf("err = %v, want %v", err, ErrApartmentNotFound)
+	}
+}
+
+func TestUpdateOwnerApartmentValidatesOwnershipRoleAndOccupiedSpots(t *testing.T) {
+	repo := &fakeApartmentRepository{
+		ownerApartment: &apartment.Apartment{ID: "apartment-1", OccupiedSpots: 2},
+	}
+	svc := NewService(repo, nil, repo, repo)
+
+	_, err := svc.UpdateOwnerApartment(context.Background(), "owner-1", "owner", "apartment-1", apartment.CreateApartmentInput{
+		Title:      "Updated flat",
+		Address:    "Main Street",
+		TotalSpots: 1,
+		BaseRent:   500,
+	})
+	if err == nil || err.Error() != "total_spots cannot be lower than occupied_spots" {
+		t.Fatalf("err = %v, want occupied spots validation", err)
+	}
+
+	_, err = svc.UpdateOwnerApartment(context.Background(), "owner-1", "tenant", "apartment-1", apartment.CreateApartmentInput{})
+	if !errors.Is(err, ErrOwnerRequired) {
+		t.Fatalf("err = %v, want %v", err, ErrOwnerRequired)
+	}
+}
+
+func TestUpdateOwnerApartmentStoresTrimmedInputWithoutPublishOnlyDescriptionParts(t *testing.T) {
+	repo := &fakeApartmentRepository{
+		ownerApartment: &apartment.Apartment{ID: "apartment-1", OccupiedSpots: 1},
+	}
+	svc := NewService(repo, nil, repo, repo)
+
+	result, err := svc.UpdateOwnerApartment(context.Background(), "owner-1", "owner", "apartment-1", apartment.CreateApartmentInput{
+		Title:         " Updated flat ",
+		Description:   " Better light ",
+		Address:       " Main Street ",
+		Area:          " Center ",
+		TotalSpots:    3,
+		Bathrooms:     9,
+		BaseRent:      500,
+		AvailableFrom: "2026-06-01",
+	})
+	if err != nil {
+		t.Fatalf("UpdateOwnerApartment returned error: %v", err)
+	}
+	if result.Title != "Updated flat" {
+		t.Fatalf("Title = %q, want trimmed title", result.Title)
+	}
+	if repo.updatedDescription != "Better light" {
+		t.Fatalf("updatedDescription = %q, want raw edited description only", repo.updatedDescription)
+	}
+	if repo.updatedTotalSpots != 3 {
+		t.Fatalf("updatedTotalSpots = %d, want 3", repo.updatedTotalSpots)
 	}
 }
 

--- a/backend/internal/apartment/service/service_test.go
+++ b/backend/internal/apartment/service/service_test.go
@@ -29,7 +29,7 @@ type fakeApartmentRepository struct {
 func (f *fakeApartmentRepository) CreateApartment(ctx context.Context, ownerID string, input apartment.CreateApartmentInput) (string, int, error) {
 	f.createdDescription = input.Description
 	f.createdStatus = input.Status
-	return "apartment-1", len(input.ImageURLs), nil
+	return "apartment-1", len(input.ImagePaths), nil
 }
 
 func (f *fakeApartmentRepository) ListOwnerApartments(ctx context.Context, ownerID string) ([]apartment.Apartment, error) {
@@ -98,17 +98,21 @@ func (f *fakeApartmentRepository) GetTenantApplicationForApartment(ctx context.C
 	return f.applicationForApartmentID, f.applicationForApartmentStatus, nil
 }
 
-type fakeImageSigner struct {
+type fakeImageStorage struct {
 	bucket    string
 	path      string
 	expiresIn int
 }
 
-func (f *fakeImageSigner) CreateSignedURL(ctx context.Context, bucket string, path string, expiresIn int) (string, error) {
+func (f *fakeImageStorage) CreateSignedURL(ctx context.Context, bucket string, path string, expiresIn int) (string, error) {
 	f.bucket = bucket
 	f.path = path
 	f.expiresIn = expiresIn
 	return "https://signed.example.test/" + path, nil
+}
+
+func (f *fakeImageStorage) UploadObject(ctx context.Context, bucket, objectPath, contentType string, fileData []byte) error {
+	return nil
 }
 
 func TestCreateApartmentAcceptsRepositoryInterfaceAndPreparesPersistenceData(t *testing.T) {
@@ -124,7 +128,7 @@ func TestCreateApartmentAcceptsRepositoryInterfaceAndPreparesPersistenceData(t *
 		Bathrooms:     1,
 		BaseRent:      400,
 		AvailableFrom: "2026-06-01",
-		ImageURLs:     []string{"https://example.test/flat.jpg"},
+		ImagePaths:    []string{"https://example.test/flat.jpg"},
 	})
 	if err != nil {
 		t.Fatalf("CreateApartment returned error: %v", err)
@@ -170,12 +174,12 @@ func TestListAvailableApartmentsReturnsTenantVisibleListings(t *testing.T) {
 func TestListOwnerApartmentsSignsImagePaths(t *testing.T) {
 	repo := &fakeApartmentRepository{
 		ownerApartments: []apartment.Apartment{{
-			ID:       "apartment-1",
-			Title:    "Flat",
-			ImageURL: "apartments/apartment-1/photo.jpg",
+			ID:         "apartment-1",
+			Title:      "Flat",
+			ImagePaths: []string{"apartments/apartment-1/photo.jpg"},
 		}},
 	}
-	signer := &fakeImageSigner{}
+	signer := &fakeImageStorage{}
 	svc := NewService(repo, signer, repo, repo)
 
 	apartments, err := svc.ListOwnerApartments(context.Background(), "owner-1", "owner")
@@ -183,30 +187,23 @@ func TestListOwnerApartmentsSignsImagePaths(t *testing.T) {
 		t.Fatalf("ListOwnerApartments returned error: %v", err)
 	}
 
-	if apartments[0].ImageURL != "https://signed.example.test/apartments/apartment-1/photo.jpg" {
-		t.Fatalf("ImageURL = %q, want signed URL", apartments[0].ImageURL)
+	if len(apartments[0].ImagePaths) == 0 || apartments[0].ImagePaths[0] != "apartments/apartment-1/photo.jpg" {
+		t.Fatalf("ImagePaths = %#v, want raw path list", apartments[0].ImagePaths)
 	}
-	if signer.bucket != "Apartment_photos" {
-		t.Fatalf("bucket = %q, want Apartment_photos", signer.bucket)
-	}
-	if signer.path != "apartments/apartment-1/photo.jpg" {
-		t.Fatalf("path = %q, want apartments/apartment-1/photo.jpg", signer.path)
-	}
-	if signer.expiresIn != 3600 {
-		t.Fatalf("expiresIn = %d, want 3600", signer.expiresIn)
+	if len(apartments[0].ImageURLs) == 0 || apartments[0].ImageURLs[0] != "https://signed.example.test/apartments/apartment-1/photo.jpg" {
+		t.Fatalf("ImageURLs = %#v, want signed URL list", apartments[0].ImageURLs)
 	}
 }
 
 func TestGetOwnerApartmentReturnsOwnedApartmentWithSignedImages(t *testing.T) {
 	repo := &fakeApartmentRepository{
 		ownerApartment: &apartment.Apartment{
-			ID:        "apartment-1",
-			Title:     "Flat",
-			ImageURL:  "apartments/apartment-1/front.jpg",
-			ImageURLs: []string{"apartments/apartment-1/front.jpg", "apartments/apartment-1/room.jpg"},
+			ID:         "apartment-1",
+			Title:      "Flat",
+			ImagePaths: []string{"apartments/apartment-1/front.jpg", "apartments/apartment-1/room.jpg"},
 		},
 	}
-	signer := &fakeImageSigner{}
+	signer := &fakeImageStorage{}
 	svc := NewService(repo, signer, repo, repo)
 
 	result, err := svc.GetOwnerApartment(context.Background(), "owner-1", "owner", "apartment-1")
@@ -217,10 +214,10 @@ func TestGetOwnerApartmentReturnsOwnedApartmentWithSignedImages(t *testing.T) {
 	if result == nil || result.ID != "apartment-1" {
 		t.Fatalf("result ID = %#v, want apartment-1", result)
 	}
-	if result.ImageURL != "https://signed.example.test/apartments/apartment-1/front.jpg" {
-		t.Fatalf("ImageURL = %q, want signed front image", result.ImageURL)
+	if len(result.ImagePaths) != 2 || result.ImagePaths[0] != "apartments/apartment-1/front.jpg" || result.ImagePaths[1] != "apartments/apartment-1/room.jpg" {
+		t.Fatalf("ImagePaths = %#v, want raw image list", result.ImagePaths)
 	}
-	if len(result.ImageURLs) != 2 || result.ImageURLs[1] != "https://signed.example.test/apartments/apartment-1/room.jpg" {
+	if len(result.ImageURLs) != 2 || result.ImageURLs[0] != "https://signed.example.test/apartments/apartment-1/front.jpg" || result.ImageURLs[1] != "https://signed.example.test/apartments/apartment-1/room.jpg" {
 		t.Fatalf("ImageURLs = %#v, want signed image list", result.ImageURLs)
 	}
 }
@@ -294,10 +291,10 @@ func TestListAvailableApartmentsSignsTenantImagePaths(t *testing.T) {
 			Title:         "Flat",
 			TotalSpots:    3,
 			OccupiedSpots: 1,
-			ImageURL:      "mock_1.avif",
+			ImagePaths:    []string{"mock_1.avif"},
 		}},
 	}
-	signer := &fakeImageSigner{}
+	signer := &fakeImageStorage{}
 	svc := NewService(repo, signer, repo, repo)
 
 	apartments, err := svc.ListAvailableApartments(context.Background())
@@ -305,8 +302,11 @@ func TestListAvailableApartmentsSignsTenantImagePaths(t *testing.T) {
 		t.Fatalf("ListAvailableApartments returned error: %v", err)
 	}
 
-	if apartments[0].ImageURL != "https://signed.example.test/mock_1.avif" {
-		t.Fatalf("ImageURL = %q, want signed URL", apartments[0].ImageURL)
+	if len(apartments[0].ImagePaths) == 0 || apartments[0].ImagePaths[0] != "mock_1.avif" {
+		t.Fatalf("ImagePaths = %#v, want raw path", apartments[0].ImagePaths)
+	}
+	if len(apartments[0].ImageURLs) == 0 || apartments[0].ImageURLs[0] != "https://signed.example.test/mock_1.avif" {
+		t.Fatalf("ImageURLs = %#v, want signed URL", apartments[0].ImageURLs)
 	}
 }
 

--- a/backend/internal/auth/supabase/client.go
+++ b/backend/internal/auth/supabase/client.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -391,6 +393,55 @@ func (c *Client) CreateSignedURL(ctx context.Context, bucket, objectPath string,
 		return "", errors.New("signed URL response is missing signedURL")
 	}
 	return completeStorageSignedURL(c.baseURL, signedURL), nil
+}
+
+// UploadObject uploads a file to a private Supabase Storage bucket.
+func (c *Client) UploadObject(ctx context.Context, bucket, objectPath, contentType string, fileData []byte) error {
+	bucket = strings.TrimSpace(bucket)
+	objectPath = strings.Trim(strings.TrimSpace(objectPath), "/")
+	if bucket == "" {
+		return errors.New("storage bucket is required")
+	}
+	if objectPath == "" {
+		return errors.New("storage object path is required")
+	}
+	if len(fileData) == 0 {
+		return errors.New("file data is required")
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", filepath.Base(objectPath))
+	if err != nil {
+		return fmt.Errorf("create multipart file: %w", err)
+	}
+	if _, err := part.Write(fileData); err != nil {
+		return fmt.Errorf("write file data: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("close multipart writer: %w", err)
+	}
+
+	storageURL := c.baseURL + "/storage/v1/object/" + url.PathEscape(bucket) + "/" + escapeStorageObjectPath(objectPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, storageURL, &body)
+	if err != nil {
+		return fmt.Errorf("create upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("apikey", c.apiKey)
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("x-upsert", "true")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request storage upload endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		raw, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("upload failed (status %d): %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return nil
 }
 
 func completeStorageSignedURL(baseURL, signedURL string) string {

--- a/backend/internal/auth/supabase/client_test.go
+++ b/backend/internal/auth/supabase/client_test.go
@@ -3,6 +3,7 @@ package supabase
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -80,5 +81,54 @@ func TestCreateSignedURLDoesNotDuplicateStoragePrefix(t *testing.T) {
 	wantSignedURL := server.URL + "/storage/v1/object/sign/apartment-photos/photo.jpg?token=abc"
 	if signedURL != wantSignedURL {
 		t.Fatalf("signedURL = %q, want %q", signedURL, wantSignedURL)
+	}
+}
+
+func TestUploadObjectPostsMultipartToStorageEndpoint(t *testing.T) {
+	var gotPath string
+	var gotAPIKey string
+	var gotAuthorization string
+	var gotFileData []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		gotAPIKey = r.Header.Get("apikey")
+		gotAuthorization = r.Header.Get("Authorization")
+
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("form file: %v", err)
+		}
+		defer file.Close()
+		gotFileData, _ = io.ReadAll(file)
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(server.URL, "secret-key")
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	err = client.UploadObject(context.Background(), "Apartment_photos", "apt-1/photo.jpg", "image/jpeg", []byte("fake-image-data"))
+	if err != nil {
+		t.Fatalf("UploadObject returned error: %v", err)
+	}
+
+	if gotPath != "/storage/v1/object/Apartment_photos/apt-1/photo.jpg" {
+		t.Fatalf("path = %q, want /storage/v1/object/Apartment_photos/apt-1/photo.jpg", gotPath)
+	}
+	if gotAPIKey != "secret-key" {
+		t.Fatalf("apikey = %q, want secret-key", gotAPIKey)
+	}
+	if gotAuthorization != "Bearer secret-key" {
+		t.Fatalf("Authorization = %q, want Bearer secret-key", gotAuthorization)
+	}
+	if string(gotFileData) != "fake-image-data" {
+		t.Fatalf("file data = %q, want fake-image-data", string(gotFileData))
 	}
 }

--- a/frontend/src/components/owner/owner_properties/OwnerPropertyGrid.tsx
+++ b/frontend/src/components/owner/owner_properties/OwnerPropertyGrid.tsx
@@ -4,9 +4,10 @@ import type { OwnerDashboardProperty } from '@/types/owner'
 
 interface OwnerPropertyGridProps {
   properties: OwnerDashboardProperty[]
+  onEdit?: (property: OwnerDashboardProperty) => void
 }
 
-export default function OwnerPropertyGrid({ properties }: OwnerPropertyGridProps) {
+export default function OwnerPropertyGrid({ properties, onEdit }: OwnerPropertyGridProps) {
   const { t } = useTranslation()
 
   if (properties.length === 0) {
@@ -45,6 +46,18 @@ export default function OwnerPropertyGrid({ properties }: OwnerPropertyGridProps
                 </div>
                 <span className={styles.ownerProgressLabel}>{t('ownerDashboard.propertyCard.percentOccupied', { percent })}</span>
               </div>
+              {onEdit ? (
+                <div className={styles.ownerPropertyActions}>
+                  <button
+                    type="button"
+                    className={styles.ownerPropertyEditButton}
+                    onClick={() => onEdit(property)}
+                    aria-label={t('ownerDashboard.propertyCard.editAria', { title: property.title })}
+                  >
+                    {t('ownerDashboard.propertyCard.edit')}
+                  </button>
+                </div>
+              ) : null}
             </div>
           </article>
         )

--- a/frontend/src/components/owner/owner_publish_property/OwnerPropertyPublishForm.tsx
+++ b/frontend/src/components/owner/owner_publish_property/OwnerPropertyPublishForm.tsx
@@ -1,11 +1,20 @@
-import { useEffect, useState, type FormEvent } from 'react'
+import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNotice } from '@/hooks/useNotice'
-import { createApartment, updateOwnerApartment } from '@/services/ownerService'
+import { createApartment, updateOwnerApartment, uploadApartmentPhotos } from '@/services/ownerService'
 import styles from '@/styles/OwnerPublishProperty.module.css'
 import type { OwnerDashboardProperty } from '@/types/owner'
 import LocationPicker from './LocationPicker'
 import type { Location } from './LocationPicker'
+
+const MAX_PHOTOS = 8
+const MAX_SIZE_MB = 5
+
+interface PhotoItem {
+  file?: File
+  preview: string
+  existingPath?: string
+}
 
 interface PublishValues {
   title: string
@@ -16,7 +25,6 @@ interface PublishValues {
   baseRent: string
   description: string
   availableFrom: string
-  imageUrls: string
   latitude?: number
   longitude?: number
 }
@@ -30,7 +38,6 @@ const initialValues: PublishValues = {
   baseRent: '350',
   description: '',
   availableFrom: '',
-  imageUrls: '',
 }
 
 interface OwnerPropertyPublishFormProps {
@@ -39,8 +46,6 @@ interface OwnerPropertyPublishFormProps {
 }
 
 function valuesFromProperty(property: OwnerDashboardProperty): PublishValues {
-  const imageUrls = property.imageUrls?.length ? property.imageUrls : property.image ? [property.image] : []
-
   return {
     title: property.title,
     address: property.address,
@@ -50,21 +55,28 @@ function valuesFromProperty(property: OwnerDashboardProperty): PublishValues {
     baseRent: String(property.rent ?? ''),
     description: property.description ?? '',
     availableFrom: '',
-    imageUrls: imageUrls.join('\n'),
     latitude: property.latitude,
     longitude: property.longitude,
   }
 }
 
+function photosFromProperty(property: OwnerDashboardProperty): PhotoItem[] {
+  const urls = property.imageUrls?.length ? property.imageUrls : property.image ? [property.image] : []
+  return urls.map((url, index) => ({ preview: url, existingPath: property.imagePaths?.[index] }))
+}
+
 export default function OwnerPropertyPublishForm({ propertyId, property }: OwnerPropertyPublishFormProps) {
   const { t } = useTranslation()
   const isEditMode = Boolean(propertyId)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const [values, setValues] = useState<PublishValues>(() => (property ? valuesFromProperty(property) : initialValues))
+  const [photos, setPhotos] = useState<PhotoItem[]>(() => (property ? photosFromProperty(property) : []))
   const [isLoading, setIsLoading] = useState(false)
   const { notice, showError, showSuccess, clearNotice } = useNotice()
 
   useEffect(() => {
     setValues(property ? valuesFromProperty(property) : initialValues)
+    setPhotos(property ? photosFromProperty(property) : [])
   }, [property])
 
   function updateField<K extends keyof PublishValues>(key: K, value: PublishValues[K]) {
@@ -81,11 +93,40 @@ export default function OwnerPropertyPublishForm({ propertyId, property }: Owner
     }))
   }
 
-  function extractImageURLs(raw: string) {
-    return raw
-      .split(/\r?\n|,/)
-      .map((entry) => entry.trim())
-      .filter((entry) => entry.length > 0)
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const selected = Array.from(event.target.files ?? [])
+    const remaining = MAX_PHOTOS - photos.length
+    const toAdd = selected.slice(0, remaining)
+
+    const valid: PhotoItem[] = []
+    for (const file of toAdd) {
+      if (file.size > MAX_SIZE_MB * 1024 * 1024) {
+        showError(t('ownerDashboard.publish.photos.tooLarge'))
+        continue
+      }
+      if (!file.type.startsWith('image/')) {
+        showError(t('ownerDashboard.publish.photos.invalidType'))
+        continue
+      }
+      valid.push({ file, preview: URL.createObjectURL(file) })
+    }
+    if (valid.length > 0) {
+      setPhotos((prev) => [...prev, ...valid])
+    }
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }
+
+  function removePhoto(index: number) {
+    setPhotos((prev) => {
+      const next = [...prev]
+      const removed = next.splice(index, 1)[0]
+      if (removed?.file) {
+        URL.revokeObjectURL(removed.preview)
+      }
+      return next
+    })
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -95,7 +136,6 @@ export default function OwnerPropertyPublishForm({ propertyId, property }: Owner
     const parsedTotalSpots = Number.parseInt(values.totalSpots, 10)
     const parsedBathrooms = Number.parseInt(values.bathrooms, 10)
     const parsedBaseRent = Number.parseInt(values.baseRent, 10)
-    const parsedImageURLs = extractImageURLs(values.imageUrls)
 
     if (values.title.trim().length < 3) {
       showError(t('ownerDashboard.publish.errors.title'))
@@ -121,6 +161,14 @@ export default function OwnerPropertyPublishForm({ propertyId, property }: Owner
     setIsLoading(true)
 
     try {
+      const newFiles = photos.filter((p) => p.file).map((p) => p.file!)
+      let uploadedPaths: string[] = photos.filter((p) => p.existingPath && !p.file).map((p) => p.existingPath!)
+
+      if (newFiles.length > 0) {
+        const results = await uploadApartmentPhotos(newFiles, propertyId, values.title.trim())
+        uploadedPaths = [...uploadedPaths, ...results.map((r) => r.path)]
+      }
+
       const payload = {
         title: values.title.trim(),
         description: values.description.trim(),
@@ -130,7 +178,7 @@ export default function OwnerPropertyPublishForm({ propertyId, property }: Owner
         bathrooms: Number.isFinite(parsedBathrooms) ? parsedBathrooms : 0,
         baseRent: parsedBaseRent,
         availableFrom: values.availableFrom || '',
-        imageUrls: parsedImageURLs,
+        imagePaths: uploadedPaths,
         latitude: values.latitude,
         longitude: values.longitude,
       }
@@ -140,6 +188,7 @@ export default function OwnerPropertyPublishForm({ propertyId, property }: Owner
       showSuccess(result.message ?? t(isEditMode ? 'ownerDashboard.publish.editSuccess' : 'ownerDashboard.publish.success'))
       if (!isEditMode) {
         setValues(initialValues)
+        setPhotos([])
       }
     } catch (error) {
       showError(error instanceof Error ? error.message : t(isEditMode ? 'ownerDashboard.publish.errors.editDefault' : 'ownerDashboard.publish.errors.default'))
@@ -245,17 +294,33 @@ export default function OwnerPropertyPublishForm({ propertyId, property }: Owner
             </label>
           ) : null}
 
-          <label className={`${styles.field} ${styles.full}`}>
-            <span className={styles.label}>{t('ownerDashboard.publish.fields.imageUrls')}</span>
-            <textarea
-              className={styles.textarea}
-              rows={3}
-              value={values.imageUrls}
-              onChange={(event) => updateField('imageUrls', event.target.value)}
-              placeholder={t('ownerDashboard.publish.placeholders.imageUrls')}
-            />
-            <span className={styles.hint}>{t('ownerDashboard.publish.hints.imageUrls')}</span>
-          </label>
+          <div className={`${styles.field} ${styles.full}`}>
+            <span className={styles.label}>{t('ownerDashboard.publish.fields.photos')}</span>
+            <div className={styles.photoGrid}>
+              {photos.map((photo, index) => (
+                <div key={`${photo.existingPath ?? photo.preview}-${index}`} className={styles.photoPreview}>
+                  <img src={photo.preview} alt="" className={styles.photoPreviewImage} />
+                  <button type="button" className={styles.photoRemoveButton} onClick={() => removePhoto(index)}>
+                    ×
+                  </button>
+                </div>
+              ))}
+              {photos.length < MAX_PHOTOS && (
+                <label className={styles.photoAddButton}>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    className={styles.photoFileInput}
+                    onChange={handleFileChange}
+                  />
+                  <span className={styles.photoAddLabel}>+</span>
+                </label>
+              )}
+            </div>
+            <span className={styles.hint}>{t('ownerDashboard.publish.hints.photos', { max: MAX_PHOTOS })}</span>
+          </div>
 
           <label className={`${styles.field} ${styles.full}`}>
             <span className={styles.label}>{t('ownerDashboard.publish.fields.description')}</span>

--- a/frontend/src/components/owner/owner_publish_property/OwnerPropertyPublishForm.tsx
+++ b/frontend/src/components/owner/owner_publish_property/OwnerPropertyPublishForm.tsx
@@ -1,8 +1,9 @@
-import { useState, type FormEvent } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNotice } from '@/hooks/useNotice'
-import { createApartment } from '@/services/ownerService'
+import { createApartment, updateOwnerApartment } from '@/services/ownerService'
 import styles from '@/styles/OwnerPublishProperty.module.css'
+import type { OwnerDashboardProperty } from '@/types/owner'
 import LocationPicker from './LocationPicker'
 import type { Location } from './LocationPicker'
 
@@ -32,11 +33,39 @@ const initialValues: PublishValues = {
   imageUrls: '',
 }
 
-export default function OwnerPropertyPublishForm() {
+interface OwnerPropertyPublishFormProps {
+  propertyId?: string
+  property?: OwnerDashboardProperty
+}
+
+function valuesFromProperty(property: OwnerDashboardProperty): PublishValues {
+  const imageUrls = property.imageUrls?.length ? property.imageUrls : property.image ? [property.image] : []
+
+  return {
+    title: property.title,
+    address: property.address,
+    area: property.area ?? '',
+    totalSpots: String(property.totalSpots),
+    bathrooms: '0',
+    baseRent: String(property.rent ?? ''),
+    description: property.description ?? '',
+    availableFrom: '',
+    imageUrls: imageUrls.join('\n'),
+    latitude: property.latitude,
+    longitude: property.longitude,
+  }
+}
+
+export default function OwnerPropertyPublishForm({ propertyId, property }: OwnerPropertyPublishFormProps) {
   const { t } = useTranslation()
-  const [values, setValues] = useState<PublishValues>(initialValues)
+  const isEditMode = Boolean(propertyId)
+  const [values, setValues] = useState<PublishValues>(() => (property ? valuesFromProperty(property) : initialValues))
   const [isLoading, setIsLoading] = useState(false)
   const { notice, showError, showSuccess, clearNotice } = useNotice()
+
+  useEffect(() => {
+    setValues(property ? valuesFromProperty(property) : initialValues)
+  }, [property])
 
   function updateField<K extends keyof PublishValues>(key: K, value: PublishValues[K]) {
     setValues((prev) => ({ ...prev, [key]: value }))
@@ -80,7 +109,7 @@ export default function OwnerPropertyPublishForm() {
       showError(t('ownerDashboard.publish.errors.totalSpots'))
       return
     }
-    if (!Number.isFinite(parsedBathrooms) || parsedBathrooms <= 0) {
+    if (!isEditMode && (!Number.isFinite(parsedBathrooms) || parsedBathrooms <= 0)) {
       showError(t('ownerDashboard.publish.errors.bathrooms'))
       return
     }
@@ -92,23 +121,28 @@ export default function OwnerPropertyPublishForm() {
     setIsLoading(true)
 
     try {
-      const result = await createApartment({
+      const payload = {
         title: values.title.trim(),
         description: values.description.trim(),
         address: values.address.trim(),
         area: values.area.trim(),
         totalSpots: parsedTotalSpots,
-        bathrooms: parsedBathrooms,
+        bathrooms: Number.isFinite(parsedBathrooms) ? parsedBathrooms : 0,
         baseRent: parsedBaseRent,
         availableFrom: values.availableFrom || '',
         imageUrls: parsedImageURLs,
         latitude: values.latitude,
         longitude: values.longitude,
-      })
-      showSuccess(result.message ?? t('ownerDashboard.publish.success'))
-      setValues(initialValues)
+      }
+      const result = isEditMode && propertyId
+        ? await updateOwnerApartment(propertyId, payload)
+        : await createApartment(payload)
+      showSuccess(result.message ?? t(isEditMode ? 'ownerDashboard.publish.editSuccess' : 'ownerDashboard.publish.success'))
+      if (!isEditMode) {
+        setValues(initialValues)
+      }
     } catch (error) {
-      showError(error instanceof Error ? error.message : t('ownerDashboard.publish.errors.default'))
+      showError(error instanceof Error ? error.message : t(isEditMode ? 'ownerDashboard.publish.errors.editDefault' : 'ownerDashboard.publish.errors.default'))
     } finally {
       setIsLoading(false)
     }
@@ -117,8 +151,8 @@ export default function OwnerPropertyPublishForm() {
   return (
     <section className={styles.pageSection}>
       <header className={styles.pageHeader}>
-        <h1 className={styles.pageTitle}>{t('ownerDashboard.publish.title')}</h1>
-        <p className={styles.pageSubtitle}>{t('ownerDashboard.publish.subtitle')}</p>
+        <h1 className={styles.pageTitle}>{t(isEditMode ? 'ownerDashboard.publish.editTitle' : 'ownerDashboard.publish.title')}</h1>
+        <p className={styles.pageSubtitle}>{t(isEditMode ? 'ownerDashboard.publish.editSubtitle' : 'ownerDashboard.publish.subtitle')}</p>
       </header>
 
       <form onSubmit={handleSubmit} className={styles.formCard}>
@@ -173,17 +207,19 @@ export default function OwnerPropertyPublishForm() {
             />
           </label>
 
-          <label className={styles.field}>
-            <span className={styles.label}>{t('ownerDashboard.publish.fields.bathrooms')}</span>
-            <input
-              type="number"
-              min={1}
-              className={styles.input}
-              value={values.bathrooms}
-              onChange={(event) => updateField('bathrooms', event.target.value)}
-              required
-            />
-          </label>
+          {!isEditMode ? (
+            <label className={styles.field}>
+              <span className={styles.label}>{t('ownerDashboard.publish.fields.bathrooms')}</span>
+              <input
+                type="number"
+                min={1}
+                className={styles.input}
+                value={values.bathrooms}
+                onChange={(event) => updateField('bathrooms', event.target.value)}
+                required
+              />
+            </label>
+          ) : null}
 
           <label className={styles.field}>
             <span className={styles.label}>{t('ownerDashboard.publish.fields.baseRent')}</span>
@@ -197,15 +233,17 @@ export default function OwnerPropertyPublishForm() {
             />
           </label>
 
-          <label className={styles.field}>
-            <span className={styles.label}>{t('ownerDashboard.publish.fields.availableFrom')}</span>
-            <input
-              type="date"
-              className={styles.input}
-              value={values.availableFrom}
-              onChange={(event) => updateField('availableFrom', event.target.value)}
-            />
-          </label>
+          {!isEditMode ? (
+            <label className={styles.field}>
+              <span className={styles.label}>{t('ownerDashboard.publish.fields.availableFrom')}</span>
+              <input
+                type="date"
+                className={styles.input}
+                value={values.availableFrom}
+                onChange={(event) => updateField('availableFrom', event.target.value)}
+              />
+            </label>
+          ) : null}
 
           <label className={`${styles.field} ${styles.full}`}>
             <span className={styles.label}>{t('ownerDashboard.publish.fields.imageUrls')}</span>
@@ -239,7 +277,9 @@ export default function OwnerPropertyPublishForm() {
 
         <div className={styles.actions}>
           <button type="submit" className={styles.primaryButton} disabled={isLoading}>
-            {isLoading ? t('ownerDashboard.publish.submitting') : t('ownerDashboard.publish.submit')}
+            {isLoading
+              ? t(isEditMode ? 'ownerDashboard.publish.editSubmitting' : 'ownerDashboard.publish.submitting')
+              : t(isEditMode ? 'ownerDashboard.publish.editSubmit' : 'ownerDashboard.publish.submit')}
           </button>
         </div>
       </form>

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -411,18 +411,17 @@ const de = {
         bathrooms: 'Bäder (wird in Beschreibung gespeichert)',
         baseRent: 'Monatspreis (EUR)',
         availableFrom: 'Verfügbar ab (wird in Beschreibung gespeichert)',
-        imageUrls: 'Bild-URLs',
+        photos: 'Wohnungsfotos',
         description: 'Beschreibung',
       },
       placeholders: {
         title: 'Helle Wohnung im Zentrum',
         address: 'Calle Ancha, 12',
         area: 'Zentrum',
-        imageUrls: 'https://.../foto1.jpg, https://.../foto2.jpg',
         description: 'Beschreibe die Wohnung, Regeln und das empfohlene Mieterprofil...',
       },
       hints: {
-        imageUrls: 'Trenne mehrere URLs mit Kommas oder Zeilenumbrüchen.',
+        photos: 'Lade bis zu {{max}} Fotos der Wohnung hoch.',
       },
       errors: {
         title: 'Der Titel muss mindestens 3 Zeichen haben.',
@@ -433,6 +432,10 @@ const de = {
         default: 'Die Wohnung konnte nicht inseriert werden. Bitte versuche es erneut.',
         editDefault: 'Die Wohnung konnte nicht aktualisiert werden. Bitte versuche es erneut.',
         loadEdit: 'Die Wohnung zum Bearbeiten konnte nicht geladen werden.',
+      },
+      photos: {
+        tooLarge: 'Die Datei überschreitet die maximale Größe von 5MB.',
+        invalidType: 'Es werden nur Bilddateien akzeptiert.',
       },
     },
     placeholder: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -360,6 +360,8 @@ const de = {
       basePrice: 'Grundpreis: {{price}} EUR',
       status: 'Status: {{status}}',
       percentOccupied: '{{percent}} % belegt',
+      edit: 'Bearbeiten',
+      editAria: '{{title}} bearbeiten',
     },
     summary: {
       title: 'Belegungsübersicht',
@@ -390,10 +392,16 @@ const de = {
     publish: {
       title: 'Wohnung inserieren',
       subtitle: 'Erstelle dein Inserat mit den wichtigsten Informationen, um Anfragen zu erhalten.',
+      editTitle: 'Wohnung bearbeiten',
+      editSubtitle: 'Aktualisiere die wichtigsten Informationen deines veröffentlichten Inserats.',
       backToProperties: 'Zurück zu meinen Wohnungen',
       submit: 'Wohnung inserieren',
       submitting: 'Wird veröffentlicht...',
       success: 'Wohnung erfolgreich inseriert.',
+      editSubmit: 'Änderungen speichern',
+      editSubmitting: 'Wird gespeichert...',
+      editSuccess: 'Wohnung erfolgreich aktualisiert.',
+      loadingEdit: 'Wohnung zum Bearbeiten wird geladen...',
       fields: {
         title: 'Titel',
         mapLocation: 'Standort auf der Karte',
@@ -423,6 +431,8 @@ const de = {
         bathrooms: 'Die Anzahl der Bäder muss größer als 0 sein.',
         baseRent: 'Der Monatspreis muss größer als 0 sein.',
         default: 'Die Wohnung konnte nicht inseriert werden. Bitte versuche es erneut.',
+        editDefault: 'Die Wohnung konnte nicht aktualisiert werden. Bitte versuche es erneut.',
+        loadEdit: 'Die Wohnung zum Bearbeiten konnte nicht geladen werden.',
       },
     },
     placeholder: {

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -360,6 +360,8 @@ const en = {
       basePrice: 'Base price: {{price}} EUR',
       status: 'Status: {{status}}',
       percentOccupied: '{{percent}}% occupied',
+      edit: 'Edit',
+      editAria: 'Edit {{title}}',
     },
     summary: {
       title: 'Occupancy summary',
@@ -390,10 +392,16 @@ const en = {
     publish: {
       title: 'List flat',
       subtitle: 'Create your listing with the main information to receive applications.',
+      editTitle: 'Edit flat',
+      editSubtitle: 'Update the main information for your published listing.',
       backToProperties: 'Back to my flats',
       submit: 'List flat',
       submitting: 'Publishing...',
       success: 'Flat listed successfully.',
+      editSubmit: 'Save changes',
+      editSubmitting: 'Saving...',
+      editSuccess: 'Flat updated successfully.',
+      loadingEdit: 'Loading flat for editing...',
       fields: {
         title: 'Title',
         mapLocation: 'Map location',
@@ -423,6 +431,8 @@ const en = {
         bathrooms: 'The number of bathrooms must be greater than 0.',
         baseRent: 'The monthly price must be greater than 0.',
         default: 'Could not list the flat. Please try again.',
+        editDefault: 'Could not update the flat. Please try again.',
+        loadEdit: 'Could not load the flat for editing.',
       },
     },
     placeholder: {

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -411,18 +411,17 @@ const en = {
         bathrooms: 'Bathrooms (saved in description)',
         baseRent: 'Monthly price (EUR)',
         availableFrom: 'Available from (saved in description)',
-        imageUrls: 'Image URLs',
+        photos: 'Flat photos',
         description: 'Description',
       },
       placeholders: {
         title: 'Bright flat in the city center',
         address: 'Calle Ancha, 12',
         area: 'City center',
-        imageUrls: 'https://.../photo1.jpg, https://.../photo2.jpg',
         description: 'Describe the flat, rules, and recommended tenant profile...',
       },
       hints: {
-        imageUrls: 'Separate multiple URLs with commas or new lines.',
+        photos: 'Upload up to {{max}} photos of the flat.',
       },
       errors: {
         title: 'Title must be at least 3 characters.',
@@ -433,6 +432,10 @@ const en = {
         default: 'Could not list the flat. Please try again.',
         editDefault: 'Could not update the flat. Please try again.',
         loadEdit: 'Could not load the flat for editing.',
+      },
+      photos: {
+        tooLarge: 'File exceeds the maximum size of 5MB.',
+        invalidType: 'Only image files are accepted.',
       },
     },
     placeholder: {

--- a/frontend/src/i18n/es.ts
+++ b/frontend/src/i18n/es.ts
@@ -360,6 +360,8 @@ const es = {
       basePrice: 'Precio base: {{price}} EUR',
       status: 'Estado: {{status}}',
       percentOccupied: '{{percent}}% ocupado',
+      edit: 'Editar',
+      editAria: 'Editar {{title}}',
     },
     summary: {
       title: 'Resumen de ocupación',
@@ -390,10 +392,16 @@ const es = {
     publish: {
       title: 'Publicar piso',
       subtitle: 'Crea tu anuncio con la información principal para recibir solicitudes.',
+      editTitle: 'Editar piso',
+      editSubtitle: 'Actualiza la información principal de tu anuncio publicado.',
       backToProperties: 'Volver a mis pisos',
       submit: 'Publicar piso',
       submitting: 'Publicando...',
       success: 'Piso publicado correctamente.',
+      editSubmit: 'Guardar cambios',
+      editSubmitting: 'Guardando...',
+      editSuccess: 'Piso actualizado correctamente.',
+      loadingEdit: 'Cargando piso para editar...',
       fields: {
         title: 'Título',
         mapLocation: 'Ubicación en el mapa',
@@ -423,6 +431,8 @@ const es = {
         bathrooms: 'El número de baños debe ser mayor que 0.',
         baseRent: 'El precio mensual debe ser mayor que 0.',
         default: 'No se pudo publicar el piso. Inténtalo de nuevo.',
+        editDefault: 'No se pudo actualizar el piso. Inténtalo de nuevo.',
+        loadEdit: 'No se pudo cargar el piso para editar.',
       },
     },
     placeholder: {

--- a/frontend/src/i18n/es.ts
+++ b/frontend/src/i18n/es.ts
@@ -411,18 +411,17 @@ const es = {
         bathrooms: 'Baños (se guarda en descripción)',
         baseRent: 'Precio mensual (EUR)',
         availableFrom: 'Disponible desde (se guarda en descripción)',
-        imageUrls: 'URLs de imágenes',
+        photos: 'Fotos del piso',
         description: 'Descripción',
       },
       placeholders: {
         title: 'Piso luminoso en el centro',
         address: 'Calle Ancha, 12',
         area: 'Centro',
-        imageUrls: 'https://.../foto1.jpg, https://.../foto2.jpg',
         description: 'Describe el piso, las normas y el perfil de inquilino recomendado...',
       },
       hints: {
-        imageUrls: 'Separa varias URL por comas o por líneas.',
+        photos: 'Sube hasta {{max}} fotos del piso.',
       },
       errors: {
         title: 'El título debe tener al menos 3 caracteres.',
@@ -433,6 +432,10 @@ const es = {
         default: 'No se pudo publicar el piso. Inténtalo de nuevo.',
         editDefault: 'No se pudo actualizar el piso. Inténtalo de nuevo.',
         loadEdit: 'No se pudo cargar el piso para editar.',
+      },
+      photos: {
+        tooLarge: 'El archivo supera el tamaño máximo de 5MB.',
+        invalidType: 'Solo se aceptan archivos de imagen.',
       },
     },
     placeholder: {

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -411,18 +411,17 @@ const fr = {
         bathrooms: 'Salles de bain (enregistré dans la description)',
         baseRent: 'Prix mensuel (EUR)',
         availableFrom: 'Disponible à partir de (enregistré dans la description)',
-        imageUrls: 'URLs des images',
+        photos: 'Photos du logement',
         description: 'Description',
       },
       placeholders: {
         title: 'Logement lumineux au centre-ville',
         address: 'Calle Ancha, 12',
         area: 'Centre-ville',
-        imageUrls: 'https://.../photo1.jpg, https://.../photo2.jpg',
         description: 'Décrivez le logement, les règles et le profil de locataire recommandé...',
       },
       hints: {
-        imageUrls: 'Séparez plusieurs URLs par des virgules ou des lignes.',
+        photos: 'Téléchargez jusqu\'à {{max}} photos du logement.',
       },
       errors: {
         title: 'Le titre doit contenir au moins 3 caractères.',
@@ -433,6 +432,10 @@ const fr = {
         default: 'Impossible de publier le logement. Réessayez.',
         editDefault: 'Impossible de mettre à jour le logement. Réessayez.',
         loadEdit: 'Impossible de charger le logement à modifier.',
+      },
+      photos: {
+        tooLarge: 'Le fichier dépasse la taille maximale de 5Mo.',
+        invalidType: 'Seuls les fichiers image sont acceptés.',
       },
     },
     placeholder: {

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -360,6 +360,8 @@ const fr = {
       basePrice: 'Prix de base : {{price}} EUR',
       status: 'État : {{status}}',
       percentOccupied: '{{percent}} % occupé',
+      edit: 'Modifier',
+      editAria: 'Modifier {{title}}',
     },
     summary: {
       title: 'Résumé d\'occupation',
@@ -390,10 +392,16 @@ const fr = {
     publish: {
       title: 'Publier un logement',
       subtitle: 'Créez votre annonce avec les informations principales pour recevoir des demandes.',
+      editTitle: 'Modifier le logement',
+      editSubtitle: 'Mettez à jour les informations principales de votre annonce publiée.',
       backToProperties: 'Retour à mes logements',
       submit: 'Publier un logement',
       submitting: 'Publication...',
       success: 'Logement publié correctement.',
+      editSubmit: 'Enregistrer',
+      editSubmitting: 'Enregistrement...',
+      editSuccess: 'Logement mis à jour correctement.',
+      loadingEdit: 'Chargement du logement à modifier...',
       fields: {
         title: 'Titre',
         mapLocation: 'Emplacement sur la carte',
@@ -423,6 +431,8 @@ const fr = {
         bathrooms: 'Le nombre de salles de bain doit être supérieur à 0.',
         baseRent: 'Le prix mensuel doit être supérieur à 0.',
         default: 'Impossible de publier le logement. Réessayez.',
+        editDefault: 'Impossible de mettre à jour le logement. Réessayez.',
+        loadEdit: 'Impossible de charger le logement à modifier.',
       },
     },
     placeholder: {

--- a/frontend/src/pages/owner/OwnerDashboardPage.test.tsx
+++ b/frontend/src/pages/owner/OwnerDashboardPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { paths } from '@/routes/paths'
@@ -31,6 +31,13 @@ function renderOwnerDashboard() {
       </Routes>
     </MemoryRouter>,
   )
+}
+
+function EditStateProbe() {
+  const location = useLocation()
+  const state = location.state as { propertyId?: string } | null
+
+  return <p>Edit property: {state?.propertyId ?? 'none'}</p>
 }
 
 describe('OwnerDashboardPage', () => {
@@ -101,5 +108,37 @@ describe('OwnerDashboardPage', () => {
     await user.click(toggleButton)
 
     expect(screen.getByRole('button', { name: /mostrar menú/i })).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  test('navigates to the publish page with the selected property id when editing', async () => {
+    const user = userEvent.setup()
+    mockedGetProfileStatus.mockResolvedValue({ role: 'owner', needsOnboarding: false })
+    mockedListOwnerApartments.mockResolvedValue([
+      {
+        id: 'apt-1',
+        title: 'Centro',
+        address: 'Calle Ancha',
+        area: 'Centro',
+        totalSpots: 3,
+        occupiedSpots: 1,
+        rent: 420,
+        status: 'AVAILABLE',
+        createdAt: '2026-05-21T10:00:00Z',
+        image: '',
+      },
+    ])
+
+    render(
+      <MemoryRouter initialEntries={[paths.ownerProperties]}>
+        <Routes>
+          <Route path={paths.ownerProperties} element={<OwnerDashboardPage />} />
+          <Route path={paths.ownerPublishProperty} element={<EditStateProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('button', { name: /editar centro/i }))
+
+    expect(await screen.findByText('Edit property: apt-1')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/owner/OwnerDashboardPage.tsx
+++ b/frontend/src/pages/owner/OwnerDashboardPage.tsx
@@ -83,6 +83,10 @@ export default function OwnerDashboardPage() {
     setIssues((prev) => prev.map((issue) => (issue.id === id ? { ...issue, status } : issue)))
   }
 
+  function handleEditProperty(property: OwnerDashboardProperty) {
+    navigate(paths.ownerPublishProperty, { state: { propertyId: property.id } })
+  }
+
   return (
     <OwnerLayout>
       <div className={styles.ownerMainGrid}>
@@ -103,7 +107,7 @@ export default function OwnerDashboardPage() {
             {isLoadingProperties ? (
               <p className={styles.ownerPropertyEmpty}>{t('ownerDashboard.properties.loading')}</p>
             ) : (
-              <OwnerPropertyGrid properties={ownerProperties} />
+              <OwnerPropertyGrid properties={ownerProperties} onEdit={handleEditProperty} />
             )}
           </section>
 

--- a/frontend/src/pages/owner/OwnerPublishPropertyPage.tsx
+++ b/frontend/src/pages/owner/OwnerPublishPropertyPage.tsx
@@ -1,13 +1,64 @@
 import { ArrowLeftIcon } from '@heroicons/react/24/outline'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import OwnerLayout from '@/components/owner/OwnerLayout'
 import OwnerPropertyPublishForm from '@/components/owner/owner_publish_property/OwnerPropertyPublishForm'
 import { paths } from '@/routes/paths'
+import { getOwnerApartment } from '@/services/ownerService'
 import styles from '@/styles/OwnerPublishProperty.module.css'
+import type { OwnerDashboardProperty } from '@/types/owner'
+
+interface OwnerPublishLocationState {
+  propertyId?: string
+}
 
 export default function OwnerPublishPropertyPage() {
   const { t } = useTranslation()
+  const location = useLocation()
+  const state = location.state as OwnerPublishLocationState | null
+  const propertyId = state?.propertyId
+  const [property, setProperty] = useState<OwnerDashboardProperty | undefined>()
+  const [loadError, setLoadError] = useState('')
+  const [isLoadingProperty, setIsLoadingProperty] = useState(Boolean(propertyId))
+
+  useEffect(() => {
+    let ignoreResult = false
+
+    async function loadPropertyForEdit() {
+      if (!propertyId) {
+        setProperty(undefined)
+        setLoadError('')
+        setIsLoadingProperty(false)
+        return
+      }
+
+      setIsLoadingProperty(true)
+      setLoadError('')
+
+      try {
+        const loadedProperty = await getOwnerApartment(propertyId)
+        if (!ignoreResult) {
+          setProperty(loadedProperty)
+        }
+      } catch (error) {
+        if (!ignoreResult) {
+          setProperty(undefined)
+          setLoadError(error instanceof Error ? error.message : t('ownerDashboard.publish.errors.loadEdit'))
+        }
+      } finally {
+        if (!ignoreResult) {
+          setIsLoadingProperty(false)
+        }
+      }
+    }
+
+    void loadPropertyForEdit()
+
+    return () => {
+      ignoreResult = true
+    }
+  }, [propertyId, t])
 
   return (
     <OwnerLayout>
@@ -15,7 +66,13 @@ export default function OwnerPublishPropertyPage() {
         <ArrowLeftIcon className={styles.backIcon} aria-hidden="true" />
         {t('ownerDashboard.publish.backToProperties')}
       </Link>
-      <OwnerPropertyPublishForm />
+      {isLoadingProperty ? (
+        <p className={styles.pageSubtitle}>{t('ownerDashboard.publish.loadingEdit')}</p>
+      ) : loadError ? (
+        <p className={styles.errorNotice} role="status">{loadError}</p>
+      ) : (
+        <OwnerPropertyPublishForm propertyId={propertyId} property={property} />
+      )}
     </OwnerLayout>
   )
 }

--- a/frontend/src/routes/AppRouter.test.tsx
+++ b/frontend/src/routes/AppRouter.test.tsx
@@ -22,6 +22,9 @@ vi.mock('@/services/authService', () => ({
 
 vi.mock('@/services/ownerService', () => ({
   listOwnerApartments: vi.fn(async () => []),
+  getOwnerApartment: vi.fn(async () => undefined),
+  createApartment: vi.fn(async () => ({})),
+  updateOwnerApartment: vi.fn(async () => ({})),
 }))
 
 vi.mock('@/components/owner/owner_publish_property/LocationPicker', () => ({

--- a/frontend/src/services/ownerService.test.ts
+++ b/frontend/src/services/ownerService.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
-import { createApartment, listOwnerApartments } from './ownerService'
+import { createApartment, getOwnerApartment, listOwnerApartments, updateOwnerApartment } from './ownerService'
 
 describe('ownerService', () => {
   beforeEach(() => {
@@ -81,6 +81,91 @@ describe('ownerService', () => {
         base_rent: 420,
         available_from: '2026-06-01',
         image_urls: ['https://example.test/1.jpg', 'https://example.test/2.jpg'],
+      }),
+    })
+  })
+
+  test('loads one owner apartment for editing', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        apartment: {
+          id: 'apt-1',
+          title: 'Centro',
+          description: 'Nice',
+          address: 'Calle Ancha',
+          area: 'Centro',
+          total_spots: 3,
+          occupied_spots: 1,
+          base_rent: 420,
+          status: 'AVAILABLE',
+          created_at: '2026-05-21T10:00:00Z',
+          image_url: 'https://example.test/apt.jpg',
+          image_urls: ['https://example.test/apt.jpg'],
+          latitude: 42.6,
+          longitude: -5.57,
+        },
+      }),
+    } as Response)
+
+    await expect(getOwnerApartment('apt-1')).resolves.toEqual({
+      id: 'apt-1',
+      title: 'Centro',
+      description: 'Nice',
+      address: 'Calle Ancha',
+      area: 'Centro',
+      totalSpots: 3,
+      occupiedSpots: 1,
+      rent: 420,
+      status: 'AVAILABLE',
+      createdAt: '2026-05-21T10:00:00Z',
+      image: 'https://example.test/apt.jpg',
+      imageUrls: ['https://example.test/apt.jpg'],
+      latitude: 42.6,
+      longitude: -5.57,
+    })
+
+    expect(fetch).toHaveBeenCalledWith('/api/owner/apartments/apt-1', { credentials: 'include' })
+  })
+
+  test('patches apartment update payload with backend field names', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: 'updated' }),
+    } as Response)
+
+    await expect(updateOwnerApartment('apt-1', {
+      title: 'Centro actualizado',
+      description: 'Brighter',
+      address: 'Calle Ancha 2',
+      area: 'Centro',
+      totalSpots: 4,
+      bathrooms: 0,
+      baseRent: 450,
+      availableFrom: '',
+      imageUrls: ['https://example.test/1.jpg'],
+      latitude: 42.6,
+      longitude: -5.57,
+    })).resolves.toEqual({ message: 'updated' })
+
+    expect(fetch).toHaveBeenCalledWith('/api/owner/apartments/apt-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify({
+        title: 'Centro actualizado',
+        description: 'Brighter',
+        address: 'Calle Ancha 2',
+        area: 'Centro',
+        total_spots: 4,
+        bathrooms: 0,
+        base_rent: 450,
+        available_from: '',
+        image_urls: ['https://example.test/1.jpg'],
+        latitude: 42.6,
+        longitude: -5.57,
       }),
     })
   })

--- a/frontend/src/services/ownerService.test.ts
+++ b/frontend/src/services/ownerService.test.ts
@@ -24,6 +24,8 @@ describe('ownerService', () => {
             status: 'AVAILABLE',
             created_at: '2026-05-21T10:00:00Z',
             image_url: 'https://example.test/apt.jpg',
+            image_urls: ['https://example.test/apt.jpg'],
+            image_paths: ['apartments/apt-1/photo.jpg'],
           },
         ],
       }),
@@ -41,6 +43,8 @@ describe('ownerService', () => {
         status: 'AVAILABLE',
         createdAt: '2026-05-21T10:00:00Z',
         image: 'https://example.test/apt.jpg',
+        imageUrls: ['https://example.test/apt.jpg'],
+        imagePaths: ['apartments/apt-1/photo.jpg'],
       },
     ])
 
@@ -62,7 +66,7 @@ describe('ownerService', () => {
       bathrooms: 1,
       baseRent: 420,
       availableFrom: '2026-06-01',
-      imageUrls: ['https://example.test/1.jpg', 'https://example.test/2.jpg'],
+      imagePaths: ['apartments/apt-1/1.jpg', 'apartments/apt-1/2.jpg'],
     })).resolves.toEqual({ message: 'created', apartmentId: 'apt-1', imagesStored: 2 })
 
     expect(fetch).toHaveBeenCalledWith('/api/apartments', {
@@ -80,7 +84,7 @@ describe('ownerService', () => {
         bathrooms: 1,
         base_rent: 420,
         available_from: '2026-06-01',
-        image_urls: ['https://example.test/1.jpg', 'https://example.test/2.jpg'],
+        image_paths: ['apartments/apt-1/1.jpg', 'apartments/apt-1/2.jpg'],
       }),
     })
   })
@@ -102,6 +106,7 @@ describe('ownerService', () => {
           created_at: '2026-05-21T10:00:00Z',
           image_url: 'https://example.test/apt.jpg',
           image_urls: ['https://example.test/apt.jpg'],
+          image_paths: ['apartments/apt-1/photo.jpg'],
           latitude: 42.6,
           longitude: -5.57,
         },
@@ -121,6 +126,7 @@ describe('ownerService', () => {
       createdAt: '2026-05-21T10:00:00Z',
       image: 'https://example.test/apt.jpg',
       imageUrls: ['https://example.test/apt.jpg'],
+      imagePaths: ['apartments/apt-1/photo.jpg'],
       latitude: 42.6,
       longitude: -5.57,
     })
@@ -143,7 +149,7 @@ describe('ownerService', () => {
       bathrooms: 0,
       baseRent: 450,
       availableFrom: '',
-      imageUrls: ['https://example.test/1.jpg'],
+      imagePaths: ['apartments/apt-1/1.jpg'],
       latitude: 42.6,
       longitude: -5.57,
     })).resolves.toEqual({ message: 'updated' })
@@ -163,7 +169,7 @@ describe('ownerService', () => {
         bathrooms: 0,
         base_rent: 450,
         available_from: '',
-        image_urls: ['https://example.test/1.jpg'],
+        image_paths: ['apartments/apt-1/1.jpg'],
         latitude: 42.6,
         longitude: -5.57,
       }),

--- a/frontend/src/services/ownerService.ts
+++ b/frontend/src/services/ownerService.ts
@@ -12,8 +12,9 @@ interface OwnerApartmentDto {
   base_rent: number
   status: string
   created_at: string
-  image_url: string
+  image_url?: string | null
   image_urls?: string[] | null
+  image_paths?: string[] | null
   latitude?: number
   longitude?: number
 }
@@ -40,7 +41,7 @@ export interface CreateApartmentInput {
   bathrooms: number
   baseRent: number
   availableFrom: string
-  imageUrls: string[]
+  imagePaths: string[]
   latitude?: number
   longitude?: number
 }
@@ -52,6 +53,7 @@ export interface CreateApartmentResult {
 }
 
 function ownerApartmentFromDto(dto: OwnerApartmentDto): OwnerDashboardProperty {
+  const imageUrls = dto.image_urls?.length ? dto.image_urls : dto.image_url ? [dto.image_url] : []
   const property: OwnerDashboardProperty = {
     id: dto.id,
     title: dto.title,
@@ -62,13 +64,16 @@ function ownerApartmentFromDto(dto: OwnerApartmentDto): OwnerDashboardProperty {
     rent: dto.base_rent,
     status: dto.status,
     createdAt: dto.created_at,
-    image: dto.image_url,
+    image: imageUrls[0] ?? '',
   }
   if (dto.description !== undefined) {
     property.description = dto.description
   }
-  if (dto.image_urls != null) {
-    property.imageUrls = dto.image_urls
+  if (imageUrls.length > 0) {
+    property.imageUrls = imageUrls
+  }
+  if (dto.image_paths != null) {
+    property.imagePaths = dto.image_paths
   }
   if (dto.latitude !== undefined) {
     property.latitude = dto.latitude
@@ -89,7 +94,7 @@ function apartmentPayload(input: CreateApartmentInput) {
     bathrooms: input.bathrooms,
     base_rent: input.baseRent,
     available_from: input.availableFrom,
-    image_urls: input.imageUrls,
+    image_paths: input.imagePaths,
     latitude: input.latitude,
     longitude: input.longitude,
   }
@@ -148,4 +153,31 @@ export async function updateOwnerApartment(propertyId: string, input: CreateApar
     apartmentId: data.apartment_id,
     imagesStored: data.images_stored,
   }
+}
+
+export interface UploadedPhoto {
+  path: string
+  signed_url: string
+}
+
+export async function uploadApartmentPhotos(files: File[], apartmentId?: string, apartmentName?: string): Promise<UploadedPhoto[]> {
+  const formData = new FormData()
+  for (const file of files) {
+    formData.append('photos', file)
+  }
+  if (apartmentId) {
+    formData.append('apartment_id', apartmentId)
+  }
+  if (apartmentName) {
+    formData.append('apartment_name', apartmentName)
+  }
+  const response = await apiFetch('/api/owner/apartment-photos', {
+    method: 'POST',
+    body: formData,
+  })
+  const data = (await response.json()) as { photos?: UploadedPhoto[]; error?: string }
+  if (!response.ok) {
+    throw new Error(data.error ?? 'No se pudieron subir las fotos.')
+  }
+  return data.photos ?? []
 }

--- a/frontend/src/services/ownerService.ts
+++ b/frontend/src/services/ownerService.ts
@@ -4,6 +4,7 @@ import type { OwnerDashboardProperty } from '@/types/owner'
 interface OwnerApartmentDto {
   id: string
   title: string
+  description?: string
   address: string
   area: string
   total_spots: number
@@ -12,10 +13,14 @@ interface OwnerApartmentDto {
   status: string
   created_at: string
   image_url: string
+  image_urls?: string[] | null
+  latitude?: number
+  longitude?: number
 }
 
 interface OwnerApartmentsResponseDto {
   apartments?: OwnerApartmentDto[]
+  apartment?: OwnerApartmentDto
   error?: string
 }
 
@@ -47,7 +52,7 @@ export interface CreateApartmentResult {
 }
 
 function ownerApartmentFromDto(dto: OwnerApartmentDto): OwnerDashboardProperty {
-  return {
+  const property: OwnerDashboardProperty = {
     id: dto.id,
     title: dto.title,
     address: dto.address,
@@ -58,6 +63,35 @@ function ownerApartmentFromDto(dto: OwnerApartmentDto): OwnerDashboardProperty {
     status: dto.status,
     createdAt: dto.created_at,
     image: dto.image_url,
+  }
+  if (dto.description !== undefined) {
+    property.description = dto.description
+  }
+  if (dto.image_urls != null) {
+    property.imageUrls = dto.image_urls
+  }
+  if (dto.latitude !== undefined) {
+    property.latitude = dto.latitude
+  }
+  if (dto.longitude !== undefined) {
+    property.longitude = dto.longitude
+  }
+  return property
+}
+
+function apartmentPayload(input: CreateApartmentInput) {
+  return {
+    title: input.title,
+    description: input.description,
+    address: input.address,
+    area: input.area,
+    total_spots: input.totalSpots,
+    bathrooms: input.bathrooms,
+    base_rent: input.baseRent,
+    available_from: input.availableFrom,
+    image_urls: input.imageUrls,
+    latitude: input.latitude,
+    longitude: input.longitude,
   }
 }
 
@@ -70,27 +104,44 @@ export async function listOwnerApartments() {
   return (data.apartments ?? []).map(ownerApartmentFromDto)
 }
 
+export async function getOwnerApartment(propertyId: string) {
+  const response = await apiFetch(`/api/owner/apartments/${encodeURIComponent(propertyId)}`)
+  const data = (await response.json()) as OwnerApartmentsResponseDto
+  if (!response.ok) {
+    throw new Error(data.error ?? 'No se pudo cargar el piso publicado.')
+  }
+  if (!data.apartment) {
+    throw new Error('No se pudo cargar el piso publicado.')
+  }
+  return ownerApartmentFromDto(data.apartment)
+}
+
 export async function createApartment(input: CreateApartmentInput): Promise<CreateApartmentResult> {
   const response = await apiFetch('/api/apartments', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      title: input.title,
-      description: input.description,
-      address: input.address,
-      area: input.area,
-      total_spots: input.totalSpots,
-      bathrooms: input.bathrooms,
-      base_rent: input.baseRent,
-      available_from: input.availableFrom,
-      image_urls: input.imageUrls,
-      latitude: input.latitude,
-      longitude: input.longitude,
-    }),
+    body: JSON.stringify(apartmentPayload(input)),
   })
   const data = (await response.json()) as CreateApartmentResponseDto
   if (!response.ok) {
     throw new Error(data.error ?? 'No se pudo publicar el piso. Intentalo de nuevo.')
+  }
+  return {
+    message: data.message,
+    apartmentId: data.apartment_id,
+    imagesStored: data.images_stored,
+  }
+}
+
+export async function updateOwnerApartment(propertyId: string, input: CreateApartmentInput): Promise<CreateApartmentResult> {
+  const response = await apiFetch(`/api/owner/apartments/${encodeURIComponent(propertyId)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(apartmentPayload(input)),
+  })
+  const data = (await response.json()) as CreateApartmentResponseDto
+  if (!response.ok) {
+    throw new Error(data.error ?? 'No se pudo actualizar el piso. Intentalo de nuevo.')
   }
   return {
     message: data.message,

--- a/frontend/src/services/tenantService.test.ts
+++ b/frontend/src/services/tenantService.test.ts
@@ -24,6 +24,7 @@ describe('tenantService', () => {
             status: 'AVAILABLE',
             created_at: '2026-05-21T10:00:00Z',
             image_url: 'https://example.test/apt.jpg',
+            image_urls: ['https://example.test/apt.jpg', 'https://example.test/apt-room.jpg'],
           },
         ],
       }),
@@ -42,7 +43,7 @@ describe('tenantService', () => {
         rent: 420,
         compatibilityScore: 0,
         status: 'available',
-        images: ['https://example.test/apt.jpg'],
+        images: ['https://example.test/apt.jpg', 'https://example.test/apt-room.jpg'],
         createdAt: '2026-05-21T10:00:00Z',
       },
     ])

--- a/frontend/src/services/tenantService.ts
+++ b/frontend/src/services/tenantService.ts
@@ -36,7 +36,9 @@ interface TenantApartmentDto {
   base_rent: number
   status: string
   created_at: string
-  image_url: string
+  image_url?: string | null
+  image_urls?: string[] | null
+  image_paths?: string[] | null
   description?: string
   owner_name?: string
   compatibility_score?: number
@@ -173,6 +175,7 @@ function tenantApartmentStatusFromDto(dto: TenantApartmentDto): PropertyAvailabi
 }
 
 function tenantApartmentFromDto(dto: TenantApartmentDto): TenantProperty {
+  const imageUrls = dto.image_urls?.length ? dto.image_urls : dto.image_url ? [dto.image_url] : []
   return {
     id: dto.id,
     titleKey: dto.title,
@@ -185,7 +188,7 @@ function tenantApartmentFromDto(dto: TenantApartmentDto): TenantProperty {
     rent: dto.base_rent,
     compatibilityScore: dto.compatibility_score ?? 0,
     status: tenantApartmentStatusFromDto(dto),
-    images: dto.image_url ? [dto.image_url] : [],
+    images: imageUrls,
     createdAt: dto.created_at,
   }
 }

--- a/frontend/src/styles/OwnerDashboard.module.css
+++ b/frontend/src/styles/OwnerDashboard.module.css
@@ -124,6 +124,7 @@
 .mobileCloseButton:focus-visible,
 .ownerNavButton:focus-visible,
 .ownerLogoutButton:focus-visible,
+.ownerPropertyEditButton:focus-visible,
 .skipLink:focus-visible {
   outline: 3px solid var(--tenant-primary);
   outline-offset: 3px;
@@ -607,6 +608,28 @@
   color: var(--tenant-text-muted);
   font-size: 0.78rem;
   font-weight: 700;
+}
+
+.ownerPropertyActions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.8rem;
+}
+
+.ownerPropertyEditButton {
+  padding: 0.5rem 0.85rem;
+  color: var(--tenant-primary);
+  font-size: 0.8rem;
+  font-weight: 800;
+  background: var(--tenant-primary-soft);
+  border: 1px solid rgba(100, 54, 199, 0.18);
+  border-radius: 0.65rem;
+  cursor: pointer;
+}
+
+.ownerPropertyEditButton:hover {
+  color: #fff;
+  background: var(--tenant-primary);
 }
 
 .ownerPropertyEmpty {

--- a/frontend/src/styles/OwnerPublishProperty.module.css
+++ b/frontend/src/styles/OwnerPublishProperty.module.css
@@ -137,25 +137,78 @@
   border: 1px solid #a7f3d0;
 }
 
-.fileList {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.35rem;
+.photoGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
-.fileItem {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.45rem 0.6rem;
-  color: var(--tenant-text-muted);
-  font-size: 0.78rem;
-  font-weight: 600;
-  background: var(--tenant-bg-soft);
+.photoPreview {
+  position: relative;
+  width: 5rem;
+  height: 5rem;
+  border-radius: 0.5rem;
+  overflow: hidden;
   border: 1px solid var(--tenant-border-light);
-  border-radius: 0.6rem;
+}
+
+.photoPreviewImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.photoRemoveButton {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 1.2rem;
+  height: 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  font-size: 0.8rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.photoAddButton {
+  width: 5rem;
+  height: 5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px dashed var(--tenant-border);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.photoAddButton:hover {
+  border-color: var(--tenant-primary);
+}
+
+.photoFileInput {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.photoAddLabel {
+  color: var(--tenant-text-soft);
+  font-size: 1.5rem;
+  font-weight: 600;
+  pointer-events: none;
 }
 
 .actions {

--- a/frontend/src/types/owner.ts
+++ b/frontend/src/types/owner.ts
@@ -32,6 +32,7 @@ export interface OwnerProfile {
 export interface OwnerDashboardProperty {
     id: string
     title: string
+    description?: string
     address: string
     area?: string
     totalSpots: number
@@ -44,6 +45,9 @@ export interface OwnerDashboardProperty {
     nextDueDate?: string
     requests?: number
     image: string
+    imageUrls?: string[]
+    latitude?: number
+    longitude?: number
 }
 
 export interface OwnerDashboardRequest {

--- a/frontend/src/types/owner.ts
+++ b/frontend/src/types/owner.ts
@@ -46,6 +46,7 @@ export interface OwnerDashboardProperty {
     requests?: number
     image: string
     imageUrls?: string[]
+    imagePaths?: string[]
     latitude?: number
     longitude?: number
 }


### PR DESCRIPTION
feat(apartment): add service-side signed image URLs; preserve image_paths
Return image_url / image_urls populated with signed URLs while keeping raw image_paths in responses and DB.
Signing is conditional — enabled only when SUPABASE_SECRET_KEY (signer) is configured.
Update DTOs and frontend mappings to accept image_url, image_urls and image_paths.
Add UploadObject support to Supabase client for multipart uploads used by the upload endpoint.
Backend and frontend tests updated to reflect new DTOs and signing behavior.
No DB migrations required; API remains backward-compatible.
Signed URL TTL is 3600s (constant) 